### PR TITLE
Fix of zombie processes

### DIFF
--- a/examples/echo_actions.cc
+++ b/examples/echo_actions.cc
@@ -34,22 +34,32 @@ public:
         // For now, just show  the first action.
         const sc2::ActionRaw& action = actions[0];
 
-        // Show the index of the ability being used.
-        last_action_text_ = GetAbilityText(action.ability_id);
 
-        // Add targeting information.
-        switch (action.target_type) {
-            case sc2::ActionRaw::TargetUnitTag:
-                last_action_text_ += "\nTargeting Unit: " + std::to_string(action.target_tag);
-                break;
+        const sc2::ActionRawUnitCommand* ptrActionRawUnitCommand=dynamic_cast<const sc2::ActionRawUnitCommand*>(&action);
 
-            case sc2::ActionRaw::TargetPosition:
-                last_action_text_ += "\nTargeting Pos: " + std::to_string(action.target_point.x) + ", " + std::to_string(action.target_point.y);
-                break;
 
-            case sc2::ActionRaw::TargetNone:
-            default:
-                last_action_text_ += "\nTargeting self";
+        if (ptrActionRawUnitCommand!=nullptr)  {
+            // Show the index of the ability being used.
+            last_action_text_ = GetAbilityText(ptrActionRawUnitCommand->ability_id);
+
+            // Add targeting information.
+            switch (ptrActionRawUnitCommand->target_type) {
+                case sc2::ActionRawUnitCommand::TargetUnitTag:
+                    last_action_text_ += "\nTargeting Unit: " + std::to_string(ptrActionRawUnitCommand->target_tag);
+                    break;
+
+                case sc2::ActionRawUnitCommand::TargetPosition:
+                    last_action_text_ += "\nTargeting Pos: " + std::to_string(ptrActionRawUnitCommand->target_point.x) + ", " + std::to_string(ptrActionRawUnitCommand->target_point.y);
+                    break;
+
+                case sc2::ActionRawUnitCommand::TargetNone:
+                default:
+                    last_action_text_ += "\nTargeting self";
+            }
+        } else {
+            const sc2::ActionRawCameraMove* ptrActionCameraMove = dynamic_cast<const sc2::ActionRawCameraMove*>(&action);
+            last_action_text_ = "Raw Camera Move\n";
+            last_action_text_ = "("+std::to_string(ptrActionCameraMove->x)+","+std::to_string(ptrActionCameraMove->y)+ ")\n";
         }
 
         debug->DebugTextOut(last_action_text_);

--- a/examples/echo_actions.cc
+++ b/examples/echo_actions.cc
@@ -32,10 +32,10 @@ public:
         last_action_text_ = "";
 
         // For now, just show  the first action.
-        const sc2::ActionRaw& action = actions[0];
+        const std::shared_ptr<sc2::ActionRaw> action = actions[0];
 
 
-        const sc2::ActionRawUnitCommand* ptrActionRawUnitCommand=dynamic_cast<const sc2::ActionRawUnitCommand*>(&action);
+        const sc2::ActionRawUnitCommand* ptrActionRawUnitCommand=dynamic_cast<const sc2::ActionRawUnitCommand*>(action.get());
 
 
         if (ptrActionRawUnitCommand!=nullptr)  {
@@ -57,9 +57,20 @@ public:
                     last_action_text_ += "\nTargeting self";
             }
         } else {
-            const sc2::ActionRawCameraMove* ptrActionCameraMove = dynamic_cast<const sc2::ActionRawCameraMove*>(&action);
-            last_action_text_ = "Raw Camera Move\n";
-            last_action_text_ = "("+std::to_string(ptrActionCameraMove->x)+","+std::to_string(ptrActionCameraMove->y)+ ")\n";
+            const sc2::ActionRawCameraMove* ptrActionCameraMove = dynamic_cast<const sc2::ActionRawCameraMove*>(action.get());
+
+            if (ptrActionCameraMove!=nullptr) {
+                last_action_text_ = "Raw Camera Move\n";
+                last_action_text_ = "("+std::to_string(ptrActionCameraMove->x)+","+std::to_string(ptrActionCameraMove->y)+ ")\n";
+            } else {
+                const sc2::ActionRawToggleAutocast* ptrActionToggleAutocast = dynamic_cast<const sc2::ActionRawToggleAutocast*>(action.get());
+
+                if (ptrActionToggleAutocast!=nullptr) {
+                    last_action_text_ = "Raw Toggle Autocast\n"+GetAbilityText(ptrActionToggleAutocast->ability_id)+"\n";
+                }
+
+            }
+
         }
 
         debug->DebugTextOut(last_action_text_);

--- a/include/sc2api/sc2_action.h
+++ b/include/sc2api/sc2_action.h
@@ -5,6 +5,7 @@
 #include "sc2_gametypes.h"
 #include <vector>
 #include <stdint.h>
+#include <memory>
 
 namespace sc2 {
 
@@ -65,6 +66,9 @@ struct ActionRawUnitCommand : public ActionRaw{
     //! Constructor.
     ActionRawUnitCommand();
 
+    bool queueCommandValid{false};
+    bool queueCommand{false};
+
     //! Comparison overload.
 
     bool operator==(const ActionRawUnitCommand& a) const {
@@ -92,7 +96,7 @@ struct ActionRawUnitCommand : public ActionRaw{
 
 };
 
-typedef std::vector<ActionRaw> RawActions;
+typedef std::vector<std::shared_ptr<ActionRaw>> RawActions;
 
 //! An action (command or ability) applied to selected units when using feature layers or the rendered interface.
 struct SpatialUnitCommand {

--- a/include/sc2api/sc2_action.h
+++ b/include/sc2api/sc2_action.h
@@ -21,9 +21,19 @@ struct ActionRawCameraMove : public ActionRaw{
     float x;
     float y;
 
-    virtual ~ActionRawCameraMove() {
+    ActionRawCameraMove();
+    virtual ~ActionRawCameraMove();
+};
 
-    }
+struct ActionRawToggleAutocast : public ActionRaw {
+    //! The ID of the ability to invoke.
+    AbilityID ability_id;
+    AbilityID raw_ability_id;
+
+    //! Units this action applies to. In normal use, this would be the currently selected units.
+    std::vector<Tag> unit_tags;
+
+    ActionRawToggleAutocast();
 };
 
 //! An action (command or ability) applied to a unit or set of units.
@@ -40,6 +50,9 @@ struct ActionRawUnitCommand : public ActionRaw{
 
     //! The ID of the ability to invoke.
     AbilityID ability_id;
+
+    AbilityID raw_ability_id;
+
     //! Units this action applies to. In normal use, this would be the currently selected units.
     std::vector<Tag> unit_tags;
     //! Which target fields are valid.
@@ -75,9 +88,7 @@ struct ActionRawUnitCommand : public ActionRaw{
     }
 
 
-    virtual ~ActionRawUnitCommand() {
-
-    }
+    virtual ~ActionRawUnitCommand();
 
 };
 

--- a/include/sc2api/sc2_action.h
+++ b/include/sc2api/sc2_action.h
@@ -8,8 +8,26 @@
 
 namespace sc2 {
 
+class ActionRaw {
+public:
+
+    virtual ~ActionRaw() {
+
+    }
+};
+
 //! An action (command or ability) applied to a unit or set of units.
-struct ActionRaw {
+struct ActionRawCameraMove : public ActionRaw{
+    float x;
+    float y;
+
+    virtual ~ActionRawCameraMove() {
+
+    }
+};
+
+//! An action (command or ability) applied to a unit or set of units.
+struct ActionRawUnitCommand : public ActionRaw{
     //! Type of target. Target types are mutually exclusive.
     enum TargetType {
         //! No target generally means 'self', e.g., a order to make a unit.
@@ -32,11 +50,11 @@ struct ActionRaw {
     Point2D target_point;
 
     //! Constructor.
-    ActionRaw();
+    ActionRawUnitCommand();
 
     //! Comparison overload.
 
-    bool operator==(const ActionRaw& a) const {
+    bool operator==(const ActionRawUnitCommand& a) const {
         if (ability_id != a.ability_id) {
             return false;
         }
@@ -52,8 +70,15 @@ struct ActionRaw {
         if (target_point.y != a.target_point.y) {
             return false;
         }
+
         return true;
     }
+
+
+    virtual ~ActionRawUnitCommand() {
+
+    }
+
 };
 
 typedef std::vector<ActionRaw> RawActions;

--- a/include/sc2api/sc2_action.h
+++ b/include/sc2api/sc2_action.h
@@ -18,7 +18,8 @@ public:
 };
 
 //! An action (command or ability) applied to a unit or set of units.
-struct ActionRawCameraMove : public ActionRaw{
+class ActionRawCameraMove : public ActionRaw{
+public:
     float x;
     float y;
 
@@ -26,7 +27,8 @@ struct ActionRawCameraMove : public ActionRaw{
     virtual ~ActionRawCameraMove();
 };
 
-struct ActionRawToggleAutocast : public ActionRaw {
+class ActionRawToggleAutocast : public ActionRaw {
+public:
     //! The ID of the ability to invoke.
     AbilityID ability_id;
     AbilityID raw_ability_id;
@@ -38,7 +40,8 @@ struct ActionRawToggleAutocast : public ActionRaw {
 };
 
 //! An action (command or ability) applied to a unit or set of units.
-struct ActionRawUnitCommand : public ActionRaw{
+class ActionRawUnitCommand : public ActionRaw{
+public:
     //! Type of target. Target types are mutually exclusive.
     enum TargetType {
         //! No target generally means 'self', e.g., a order to make a unit.

--- a/include/sc2api/sc2_coordinator.h
+++ b/include/sc2api/sc2_coordinator.h
@@ -203,6 +203,8 @@ public:
     //!< \return The game executable path.
     std::string GetExePath() const;
 
+    void waitPID();
+    void terminate();
 private:
     CoordinatorImp* imp_;
 };

--- a/include/sc2api/sc2_errors.h
+++ b/include/sc2api/sc2_errors.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <exception>
+
+class ClientResponseError : public std::exception {
+public:
+ std::string reason="";
+ ClientResponseError(const char* reason) {
+	this->reason = std::string(reason);
+ }
+ virtual const char* what() const throw() {
+	return reason.c_str();
+ }
+
+};

--- a/src/sc2api/sc2_action.cc
+++ b/src/sc2api/sc2_action.cc
@@ -9,8 +9,25 @@ namespace sc2 {
 
 ActionRawUnitCommand::ActionRawUnitCommand() :
     ability_id(0),
+    raw_ability_id(0),
     target_type(TargetNone),
     target_tag(NullTag) {
+}
+
+ActionRawUnitCommand::~ActionRawUnitCommand() {
+
+}
+
+ActionRawToggleAutocast::ActionRawToggleAutocast() : ability_id(0), raw_ability_id(0) {
+
+}
+
+ActionRawCameraMove::ActionRawCameraMove() : x(0.0), y(0.0) {
+
+}
+
+ActionRawCameraMove::~ActionRawCameraMove() {
+
 }
 
 }

--- a/src/sc2api/sc2_action.cc
+++ b/src/sc2api/sc2_action.cc
@@ -7,7 +7,7 @@
 
 namespace sc2 {
 
-ActionRaw::ActionRaw() :
+ActionRawUnitCommand::ActionRawUnitCommand() :
     ability_id(0),
     target_type(TargetNone),
     target_tag(NullTag) {

--- a/src/sc2api/sc2_client.cc
+++ b/src/sc2api/sc2_client.cc
@@ -557,9 +557,9 @@ bool ObservationImp::UpdateObservation() {
 
     // Remap ability ids.
     {
-        for (ActionRaw& action : raw_actions_) {
-            ActionRawUnitCommand* ptrActionUnitCommand = dynamic_cast<ActionRawUnitCommand*>(&action);
-            ActionRawToggleAutocast* ptrActionToggleAutocast = dynamic_cast<ActionRawToggleAutocast*>(&action);
+        for (std::shared_ptr<ActionRaw> action : raw_actions_) {
+            ActionRawUnitCommand* ptrActionUnitCommand = dynamic_cast<ActionRawUnitCommand*>(action.get());
+            ActionRawToggleAutocast* ptrActionToggleAutocast = dynamic_cast<ActionRawToggleAutocast*>(action.get());
 
             if (ptrActionUnitCommand!=nullptr) {
                 ptrActionUnitCommand->ability_id = GetGeneralizedAbilityID(ptrActionUnitCommand->ability_id, *this);

--- a/src/sc2api/sc2_client.cc
+++ b/src/sc2api/sc2_client.cc
@@ -558,7 +558,11 @@ bool ObservationImp::UpdateObservation() {
     // Remap ability ids.
     {
         for (ActionRaw& action : raw_actions_) {
-            action.ability_id = GetGeneralizedAbilityID(action.ability_id, *this);
+            ActionRawUnitCommand* ptrActionUnitCommand = dynamic_cast<ActionRawUnitCommand*>(&action);
+
+            if (ptrActionUnitCommand!=nullptr) {
+                ptrActionUnitCommand->ability_id = GetGeneralizedAbilityID(ptrActionUnitCommand->ability_id, *this);
+            }
         }
         for (SpatialUnitCommand& spatial_action : feature_layer_actions_.unit_commands) {
             spatial_action.ability_id = GetGeneralizedAbilityID(spatial_action.ability_id, *this);

--- a/src/sc2api/sc2_client.cc
+++ b/src/sc2api/sc2_client.cc
@@ -559,10 +559,15 @@ bool ObservationImp::UpdateObservation() {
     {
         for (ActionRaw& action : raw_actions_) {
             ActionRawUnitCommand* ptrActionUnitCommand = dynamic_cast<ActionRawUnitCommand*>(&action);
+            ActionRawToggleAutocast* ptrActionToggleAutocast = dynamic_cast<ActionRawToggleAutocast*>(&action);
 
             if (ptrActionUnitCommand!=nullptr) {
                 ptrActionUnitCommand->ability_id = GetGeneralizedAbilityID(ptrActionUnitCommand->ability_id, *this);
+            } else
+            if (ptrActionToggleAutocast!=nullptr) {
+                ptrActionToggleAutocast->ability_id = GetGeneralizedAbilityID(ptrActionToggleAutocast->ability_id, *this);
             }
+
         }
         for (SpatialUnitCommand& spatial_action : feature_layer_actions_.unit_commands) {
             spatial_action.ability_id = GetGeneralizedAbilityID(spatial_action.ability_id, *this);

--- a/src/sc2api/sc2_coordinator.cc
+++ b/src/sc2api/sc2_coordinator.cc
@@ -4,10 +4,10 @@
 #include "sc2api/sc2_args.h"
 #include "sc2api/sc2_interfaces.h"
 #include "sc2api/sc2_control_interfaces.h"
+#include "sc2api/sc2_errors.h"
 
 #include "sc2utils/sc2_manage_process.h"
 #include "sc2utils/sc2_scan_directory.h"
-
 #include "s2clientprotocol/sc2api.pb.h"
 
 #include <algorithm>
@@ -97,6 +97,13 @@ bool AttachClients(ProcessSettings& process_settings, std::vector<Client*> clien
         Client* c = clients[i];
 
         connected = c->Control()->Connect(process_settings.net_address, pi.port, process_settings.timeout_ms);
+
+        if (!connected) {
+		std::cerr << "AttachClients: Attach to clients failed" << std::endl;
+		ClientResponseError error("AttachClients: Attach to clients failed");
+		throw error;
+	}
+
         assert(connected);
     }
 

--- a/src/sc2api/sc2_coordinator.cc
+++ b/src/sc2api/sc2_coordinator.cc
@@ -16,6 +16,9 @@
 #include <cassert>
 #include <thread>
 
+#include <sys/types.h>
+#include <sys/wait.h>
+
 namespace sc2 {
 
 void RunParallel(const std::function<void(Agent* a)>& step, std::vector<Agent*>& agents) {
@@ -840,6 +843,18 @@ bool Coordinator::AllGamesEnded() const {
     }
 
     return true;
+}
+void Coordinator::waitPID() {
+   if (imp_->process_settings_.process_info.size()>0) {
+   	int status;
+	waitpid(imp_->process_settings_.process_info.back().process_id, &status, 0);
+   }
+}
+
+void Coordinator::terminate() {
+   if (imp_->process_settings_.process_info.size()>0) {
+   	sc2::TerminateProcess(imp_->process_settings_.process_info.back().process_id);
+   }
 }
 
 void CoordinatorImp::AddAgent(Agent* agent) {

--- a/src/sc2api/sc2_proto_to_pods.cc
+++ b/src/sc2api/sc2_proto_to_pods.cc
@@ -340,7 +340,7 @@ void ConvertRawActions(const ResponseObservationPtr& response_observation_ptr, R
             continue;
         }
         const SC2APIProtocol::ActionRaw& action_raw = proto_action.action_raw();
-        if (!(action_raw.has_unit_command() || action_raw.has_camera_move())) {
+        if (!(action_raw.has_unit_command() || action_raw.has_camera_move()) || action_raw.has_toggle_autocast()) {
             continue;
         }
 
@@ -353,6 +353,7 @@ void ConvertRawActions(const ResponseObservationPtr& response_observation_ptr, R
             // Construct and push the relevant action.
             ActionRawUnitCommand action;
             action.ability_id = AbilityID(action_raw_command.ability_id());
+            action.raw_ability_id = action_raw_command.ability_id();
 
             if (action_raw_command.has_target_unit_tag()) {
                 action.target_type = ActionRawUnitCommand::TargetUnitTag;
@@ -383,6 +384,19 @@ void ConvertRawActions(const ResponseObservationPtr& response_observation_ptr, R
             cameraMove.x = center_world_space.x();
             cameraMove.y = center_world_space.y();
             actions.push_back(cameraMove);
+        }
+
+        if (action_raw.has_toggle_autocast()) {
+            const SC2APIProtocol::ActionRawToggleAutocast& action_raw_toggle_autocast = action_raw.toggle_autocast();
+
+            ActionRawToggleAutocast actionToggleAutocast;
+            actionToggleAutocast.ability_id = AbilityID(action_raw_toggle_autocast.ability_id());
+            actionToggleAutocast.raw_ability_id = action_raw_toggle_autocast.ability_id();
+
+            for (int j = 0; j < action_raw_toggle_autocast.unit_tags_size(); ++j)
+                actionToggleAutocast.unit_tags.push_back(action_raw_toggle_autocast.unit_tags(j));
+
+             actions.push_back(actionToggleAutocast);
         }
     }
 }

--- a/src/sc2api/sc2_replay_observer.cc
+++ b/src/sc2api/sc2_replay_observer.cc
@@ -4,6 +4,8 @@
 #include "sc2api/sc2_proto_to_pods.h"
 #include "sc2api/sc2_game_settings.h"
 
+#include "sc2api/sc2_errors.h"
+
 #include <iostream>
 
 namespace sc2 {
@@ -193,6 +195,8 @@ bool ReplayControlImp::WaitForReplay() {
     GameResponsePtr response = control_interface_->WaitForResponse();
     if (!response.get()) {
         std::cerr << "WaitForReplay: timed out, did not receive any response." << std::endl;
+        ClientResponseError error("WaitForReplay: timed out, did not receive any response.");
+	throw error;
         assert(0);
         return false;
     }


### PR DESCRIPTION
This patch encompasses several fixes to extract replay data concurrently in a larger manner.
When trying to do this using the CPP-SC2 API zombie process arose. 
There were also problems showing up with SC2 Headless clients that didn't respond anymore and the API just exited. 
To recognize this problem better an exception has been introduced.

It is now recommended to call waitForPID after the 
while (coordinator.Update());
loop has been finished.

As the waitForPID might wait forever it is advisory to introduce some kind of a watchdog facility with:

        std::cout << "Waiting for PID" << std::endl;

        std::thread watchDog = std::thread([&]() {
            std::this_thread::sleep_for(std::chrono::seconds(3));
            std::cout << "Terminating..." << std::endl;
            coordinator.terminate();
            std::cout << "Terminating done..." << std::endl;
        });

        coordinator.waitPID();
        watchDog.join();