### PR TITLE
feat: Allow ActionImp::UnitCommand to use sc2::Tag

### DIFF
--- a/include/sc2api/sc2_interfaces.h
+++ b/include/sc2api/sc2_interfaces.h
@@ -340,19 +340,49 @@ public:
     //! Issues a command to multiple units (prefer this where possible). Same as UnitCommand(Unit, AbilityID, Unit).
     virtual void UnitCommand(const Units& units, AbilityID ability, const Unit* target, bool queued_command = false) = 0;
 
+    //! Issues a command to a unit. Self targeting.
+    //!< \param tag Tag of unit.
+    //!< \param ability The ability id of the command.
+    virtual void UnitCommand(Tag tag, AbilityID ability, bool queued_command = false) = 0;
+
+    //! Issues a command to a unit. Targets a point.
+    //!< \param tag Tag of unit.
+    //!< \param ability The ability id of the command.
+    //!< \param point The 2D world position to target.
+    virtual void UnitCommand(Tag tag, AbilityID ability, const Point2D& point, bool queued_command = false) = 0;
+
+    //! Issues a command to a unit. Targets another unit.
+    //!< \param tag Tag of unit.
+    //!< \param ability The ability id of the command.
+    //!< \param target_tag Tag of unit that is a target of the unit getting the command.
+    virtual void UnitCommand(Tag tag, AbilityID ability, const Tag target_tag, bool queued_command = false) = 0;
+
+    //! Issues a command to multiple units (prefer this where possible). Same as UnitCommand(Tag, AbilityID).
+    //!< \param tags Tags of units.
+    virtual void UnitCommand(const Tags& tags, AbilityID ability, bool queued_move = false) = 0;
+
+    //! Issues a command to multiple units (prefer this where possible). Same as UnitCommand(Tag, AbilityID, Point2D).
+    //!< \param tags Tags of units.
+    virtual void UnitCommand(const Tags& tags, AbilityID ability, const Point2D& point, bool queued_command = false) = 0;
+
+    //! Issues a command to multiple units (prefer this where possible). Same as UnitCommand(Tag, AbilityID, Tag).
+    //!< \param tags Tags of units.
+    virtual void UnitCommand(const Tags& tags, AbilityID ability, const Tag target_tag, bool queued_command = false) = 0;
+
     //! Returns a list of unit tags that have sent commands out in the last call to SendActions. This will be used to determine
     //! if a unit actually has a command when the observation is received.
     //!< \return Array of units that have sent commands.
-    virtual const std::vector<Tag>& Commands() const = 0;
+    virtual const Tags& Commands() const = 0;
 
     //! Enables or disables autocast of an ability on a unit.
     //!< \param unit_tag The unit to toggle the ability on.
     //!< \param ability The ability to be toggled.
     virtual void ToggleAutocast(Tag unit_tag, AbilityID ability) = 0;
+
     //! Enables or disables autocast of an ability on a list of units.
     //!< \param unit_tags The units to toggle the ability on.
     //!< \param ability The ability to be toggled.
-    virtual void ToggleAutocast(const std::vector<Tag>& unit_tags, AbilityID ability) = 0;
+    virtual void ToggleAutocast(const Tags& unit_tags, AbilityID ability) = 0;
 
     //! Sends a message to the game chat.
     //!< \param message Text of message to send.

--- a/include/sc2api/sc2_unit.h
+++ b/include/sc2api/sc2_unit.h
@@ -218,7 +218,10 @@ public:
 };
 
 typedef std::vector<const Unit*> Units;
+typedef std::vector<Tag> Tags;
 typedef std::unordered_map<Tag, size_t> UnitIdxMap;
+
+Tags ConvertToTags(const Units& units);
 
 struct UnitDamage {
     const Unit* unit;

--- a/src/sc2api/sc2_agent.cc
+++ b/src/sc2api/sc2_agent.cc
@@ -26,17 +26,23 @@ public:
     void UnitCommand(const Units& units, AbilityID ability, bool queued_command = false) override;
     void UnitCommand(const Units& units, AbilityID ability, const Point2D& point, bool queued_command = false) override;
     void UnitCommand(const Units& units, AbilityID ability, const Unit* target, bool queued_command = false) override;
+    void UnitCommand(Tag tag, AbilityID ability, bool queued_command = false) override;
+    void UnitCommand(Tag tag, AbilityID ability, const Point2D& point, bool queued_command = false) override;
+    void UnitCommand(Tag tag, AbilityID ability, const Tag target_tag, bool queued_command = false) override;
+    void UnitCommand(const Tags& tags, AbilityID ability, bool queued_command = false) override;
+    void UnitCommand(const Tags& tags, AbilityID ability, const Point2D& point, bool queued_command = false) override;
+    void UnitCommand(const Tags& tags, AbilityID ability, const Tag target_tag, bool queued_command = false) override;
 
     void ToggleAutocast(Tag unit_tag, AbilityID ability) override;
-    void ToggleAutocast(const std::vector<Tag>& unit_tags, AbilityID ability) override;
+    void ToggleAutocast(const Tags& unit_tags, AbilityID ability) override;
 
     void SendChat(const std::string& message, ChatChannel channel) override;
 
-    const std::vector<Tag>& Commands() const override;
+    const Tags& Commands() const override;
 
     void SendActions() override;
 
-    std::vector<Tag> commands_;
+    Tags commands_;
 };
 
 ActionImp::ActionImp(ProtoInterface& proto, ControlInterface& control) :
@@ -51,7 +57,7 @@ SC2APIProtocol::RequestAction* ActionImp::GetRequestAction() {
     return request_actions_->mutable_action();
 }
 
-const std::vector<Tag>& ActionImp::Commands() const {
+ const Tags& ActionImp::Commands() const {
     return commands_;
 }
 
@@ -81,11 +87,11 @@ void ActionImp::SendActions() {
 }
 
 void ActionImp::ToggleAutocast(Tag unit_tag, AbilityID ability) {
-    std::vector<Tag> tags = { unit_tag };
+    Tags tags = { unit_tag };
     ToggleAutocast(tags, ability);
 }
 
-void ActionImp::ToggleAutocast(const std::vector<Tag>& unit_tags, AbilityID ability) {
+void ActionImp::ToggleAutocast(const Tags& unit_tags, AbilityID ability) {
     SC2APIProtocol::RequestAction* request_action = GetRequestAction();
     SC2APIProtocol::Action* action = request_action->add_actions();
     SC2APIProtocol::ActionRaw* action_raw = action->mutable_action_raw();
@@ -122,66 +128,112 @@ void ActionImp::SendChat(const std::string& message, ChatChannel channel) {
 
 void ActionImp::UnitCommand(const Unit* unit, AbilityID ability, bool queued_command) {
     if (!unit) return;
-    UnitCommand(Units({ unit }), ability, queued_command);
+    UnitCommand(unit->tag, ability, queued_command);
 }
 
 void ActionImp::UnitCommand(const Unit* unit, AbilityID ability, const Point2D& point, bool queued_command) {
     if (!unit) return;
-    UnitCommand(Units({ unit }), ability, point, queued_command);
+    UnitCommand(unit->tag, ability, point, queued_command);
 }
 
 void ActionImp::UnitCommand(const Unit* unit, AbilityID ability, const Unit* target, bool queued_command) {
     if (!unit || !target) return;
-    UnitCommand(Units({ unit }), ability, target, queued_command);
+    UnitCommand(unit->tag, ability, target->tag, queued_command);
 }
 
 void ActionImp::UnitCommand(const Units& units, AbilityID ability, bool queued_command) {
-    SC2APIProtocol::RequestAction* request_action = GetRequestAction();
-    SC2APIProtocol::Action* action = request_action->add_actions();
-    SC2APIProtocol::ActionRaw* action_raw = action->mutable_action_raw();
-    SC2APIProtocol::ActionRawUnitCommand* unit_command = action_raw->mutable_unit_command();
-
-    unit_command->set_ability_id(ability);
-    unit_command->set_queue_command(queued_command);
-
-    for (auto unit : units) {
-        if (!unit) continue;
-        unit_command->add_unit_tags(unit->tag);
-    }
+    Tags tags = sc2::ConvertToTags(units);
+    UnitCommand(tags, ability, queued_command);
 }
 
 void ActionImp::UnitCommand(const Units& units, AbilityID ability, const Point2D& point, bool queued_command) {
-    SC2APIProtocol::RequestAction* request_action = GetRequestAction();
-    SC2APIProtocol::Action* action = request_action->add_actions();
-    SC2APIProtocol::ActionRaw* action_raw = action->mutable_action_raw();
-    SC2APIProtocol::ActionRawUnitCommand* unit_command = action_raw->mutable_unit_command();
-
-    unit_command->set_ability_id(ability);
-    SC2APIProtocol::Point2D* target_point = unit_command->mutable_target_world_space_pos();
-    target_point->set_x(point.x);
-    target_point->set_y(point.y);
-    unit_command->set_queue_command(queued_command);
-
-    for (auto unit : units) {
-        if (!unit) continue;
-        unit_command->add_unit_tags(unit->tag);
-    }
+    Tags tags = sc2::ConvertToTags(units);
+    UnitCommand(tags, ability, point, queued_command);
 }
 
 void ActionImp::UnitCommand(const Units& units, AbilityID ability, const Unit* target, bool queued_command) {
+    Tags tags = sc2::ConvertToTags(units);
+    UnitCommand(tags, ability, target->tag, queued_command);
+}
+
+void ActionImp::UnitCommand(Tag tag, AbilityID ability, bool queued_command) {
     SC2APIProtocol::RequestAction* request_action = GetRequestAction();
     SC2APIProtocol::Action* action = request_action->add_actions();
     SC2APIProtocol::ActionRaw* action_raw = action->mutable_action_raw();
-    SC2APIProtocol::ActionRawUnitCommand* unit_command = action_raw->mutable_unit_command();
+    SC2APIProtocol::ActionRawUnitCommand* tag_command = action_raw->mutable_unit_command();
 
-    unit_command->set_ability_id(ability);
-    unit_command->set_target_unit_tag(target->tag);
-    unit_command->set_queue_command(queued_command);
+    tag_command->set_ability_id(ability);
+    tag_command->set_queue_command(queued_command);
+    tag_command->add_unit_tags(tag);
+}
 
-    for (auto unit : units) {
-        if (!unit) continue;
-        unit_command->add_unit_tags(unit->tag);
-    }
+void ActionImp::UnitCommand(Tag tag, AbilityID ability, const Point2D& point, bool queued_command) {
+    SC2APIProtocol::RequestAction* request_action = GetRequestAction();
+    SC2APIProtocol::Action* action = request_action->add_actions();
+    SC2APIProtocol::ActionRaw* action_raw = action->mutable_action_raw();
+    SC2APIProtocol::ActionRawUnitCommand* tag_command = action_raw->mutable_unit_command();
+
+    tag_command->set_ability_id(ability);
+    SC2APIProtocol::Point2D* target_point = tag_command->mutable_target_world_space_pos();
+    target_point->set_x(point.x);
+    target_point->set_y(point.y);
+    tag_command->set_queue_command(queued_command);
+    tag_command->add_unit_tags(tag);
+}
+
+void ActionImp::UnitCommand(Tag tag, AbilityID ability, const Tag target_tag, bool queued_command) {
+    SC2APIProtocol::RequestAction* request_action = GetRequestAction();
+    SC2APIProtocol::Action* action = request_action->add_actions();
+    SC2APIProtocol::ActionRaw* action_raw = action->mutable_action_raw();
+    SC2APIProtocol::ActionRawUnitCommand* tag_command = action_raw->mutable_unit_command();
+
+    tag_command->set_ability_id(ability);
+    tag_command->set_target_unit_tag(target_tag);
+    tag_command->set_queue_command(queued_command);
+    tag_command->add_unit_tags(tag);
+}
+
+void ActionImp::UnitCommand(const Tags& tags, AbilityID ability, bool queued_command) {
+    SC2APIProtocol::RequestAction* request_action = GetRequestAction();
+    SC2APIProtocol::Action* action = request_action->add_actions();
+    SC2APIProtocol::ActionRaw* action_raw = action->mutable_action_raw();
+    SC2APIProtocol::ActionRawUnitCommand* tag_command = action_raw->mutable_unit_command();
+
+    tag_command->set_ability_id(ability);
+    tag_command->set_queue_command(queued_command);
+
+    for (auto tag : tags)
+        tag_command->add_unit_tags(tag);
+}
+
+void ActionImp::UnitCommand(const Tags& tags, AbilityID ability, const Point2D& point, bool queued_command) {
+    SC2APIProtocol::RequestAction* request_action = GetRequestAction();
+    SC2APIProtocol::Action* action = request_action->add_actions();
+    SC2APIProtocol::ActionRaw* action_raw = action->mutable_action_raw();
+    SC2APIProtocol::ActionRawUnitCommand* tag_command = action_raw->mutable_unit_command();
+
+    tag_command->set_ability_id(ability);
+    SC2APIProtocol::Point2D* target_point = tag_command->mutable_target_world_space_pos();
+    target_point->set_x(point.x);
+    target_point->set_y(point.y);
+    tag_command->set_queue_command(queued_command);
+
+    for (auto tag : tags)
+        tag_command->add_unit_tags(tag);
+}
+
+void ActionImp::UnitCommand(const Tags& tags, AbilityID ability, const Tag target_tag, bool queued_command) {
+    SC2APIProtocol::RequestAction* request_action = GetRequestAction();
+    SC2APIProtocol::Action* action = request_action->add_actions();
+    SC2APIProtocol::ActionRaw* action_raw = action->mutable_action_raw();
+    SC2APIProtocol::ActionRawUnitCommand* tag_command = action_raw->mutable_unit_command();
+
+    tag_command->set_ability_id(ability);
+    tag_command->set_target_unit_tag(target_tag);
+    tag_command->set_queue_command(queued_command);
+
+    for (auto tag : tags)
+        tag_command->add_unit_tags(tag);
 }
 
 

--- a/src/sc2api/sc2_client.cc
+++ b/src/sc2api/sc2_client.cc
@@ -923,7 +923,7 @@ public:
     };
     std::vector<DebugUnit> debug_unit_;
 
-    std::vector<Tag> debug_kill_tag_;
+    Tags debug_kill_tag_;
 
     bool has_move_camera;
     Point2D debug_move_camera_;
@@ -1418,10 +1418,10 @@ public:
     void Error(ClientError error, const std::vector<std::string>& errors = {}) override;
     void ErrorIf(bool condition, ClientError error, const std::vector<std::string>& errors = {}) override;
 
-    bool IssueEvents(const std::vector<Tag>& commands = {}) override;
+    bool IssueEvents(const Tags& commands = {}) override;
     void IssueUnitDestroyedEvents();
     void IssueUnitAddedEvents();
-    void IssueIdleEvents(const std::vector<Tag>& commands);
+    void IssueIdleEvents(const Tags& commands);
     void IssueBuildingCompletedEvents();
     void IssueUnitDamagedEvents();
 
@@ -2073,7 +2073,7 @@ void ControlImp::IssueUnitDamagedEvents() {
     }
 }
 
-void ControlImp::IssueIdleEvents(const std::vector<Tag>& commands) {
+void ControlImp::IssueIdleEvents(const Tags& commands) {
     auto& unit_pool = observation_imp_->unit_pool_;
     // identify idled units where commands were issued last step, but units have no orders now (maybe failed, maybe executed instantly)
     for (auto t : commands) {
@@ -2132,7 +2132,7 @@ void ControlImp::IssueUpgradeEvents() {
     }
 }
 
-bool ControlImp::IssueEvents(const std::vector<Tag>& commands) {
+bool ControlImp::IssueEvents(const Tags& commands) {
     if (observation_imp_->current_game_loop_ == observation_imp_->previous_game_loop) {
         return false;
     }

--- a/src/sc2api/sc2_unit.cc
+++ b/src/sc2api/sc2_unit.cc
@@ -14,6 +14,16 @@ bool Unit::IsBuildFinished() const {
     return build_progress >= 1.0f;
 }
 
+Tags ConvertToTags(const Units& units) {
+    Tags tags;
+    std::transform(std::begin(units),
+        std::end(units),
+        std::back_inserter(tags),
+        [](const Unit* unit) {return unit->tag; });
+
+    return tags;
+}
+
 Unit* UnitPool::CreateUnit(Tag tag) {
     Unit* existing = GetUnit(tag);
     if (existing) {

--- a/tests/test_unit_command_common.cc
+++ b/tests/test_unit_command_common.cc
@@ -63,15 +63,6 @@ namespace sc2 {
         return offset_point;
     }
 
-    std::vector<Tag> TestUnitCommand::GetTagListFromUnits(Units units) {
-        std::vector<Tag> tags;
-        for (const auto& unit : units) {
-            tags.push_back(unit->tag);
-        }
-
-        return tags;
-    }
-
     void TestUnitCommand::SetOriginPoint() {
         const GameInfo& game_info = agent_->Observation()->GetGameInfo();
         origin_pt_ = FindCenterOfMap(game_info);

--- a/tests/test_unit_command_common.h
+++ b/tests/test_unit_command_common.h
@@ -38,7 +38,6 @@ namespace sc2 {
         virtual void AdditionalTestSetup();
         virtual void IssueUnitCommand(ActionInterface* act);
         virtual Point2D GetPointOffsetX(Point2D starting_point, float offset = 5);
-        virtual std::vector<Tag> GetTagListFromUnits(Units units);
         virtual void SetOriginPoint();
         virtual void SetTestTime();
         virtual void VerifyUnitOrders(const Unit* unit, ABILITY_ID test_ability);


### PR DESCRIPTION
I think I have it except for the abstraction.  In the tests I couldn't figure out a more concise way other than overriding the IssueUnitCommand() function, to explicitly call the Tag overloads of ActionImp::UnitCommand().  
I'll try and get my sticking points listed with the abstraction, soon.  Basically, when making the struct, if it is derived from ActionImp, then I can use the member function   GetRequestAction() to consolidate that first mess. 
```
    SC2APIProtocol::RequestAction* request_action = GetRequestAction();
    SC2APIProtocol::Action* action = request_action->add_actions();
    SC2APIProtocol::ActionRaw* action_raw = action->mutable_action_raw();
    SC2APIProtocol::ActionRawUnitCommand* tag_command = action_raw->mutable_unit_command();
```
But then I get a little lost in how the other parameters (abiliity, point, queued_command) get picked up.
Trying to default initialize the parameters in the struct constructor, seems to lead me into more overloads, which probably aren't needed. 
Now that I have the tests done and am understanding the inheritance in the tests, I'll take another few attempts at the abstraction and get my sticking points drawn up better.