### PR TITLE
build: msvc cmake cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
+cmake_policy(VERSION 3.15)
 
 project(cpp-sc2)
 
@@ -35,44 +36,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${PROJECT_BINARY_DIR}/bin)
 # Build with c++14 support.
 set(CMAKE_CXX_STANDARD 14)
 
-# Disable default libraries in visual studio
-if (MSVC)
-    # Default to statically-linked runtime.
-    if("${MSVC_RUNTIME}" STREQUAL "")
-        set(MSVC_RUNTIME "static")
-    endif()
-
-    # Set compiler options.
-    set(variables
-        CMAKE_C_FLAGS_DEBUG
-        CMAKE_C_FLAGS_MINSIZEREL
-        CMAKE_C_FLAGS_RELEASE
-        CMAKE_C_FLAGS_RELWITHDEBINFO
-        CMAKE_CXX_FLAGS_DEBUG
-        CMAKE_CXX_FLAGS_MINSIZEREL
-        CMAKE_CXX_FLAGS_RELEASE
-        CMAKE_CXX_FLAGS_RELWITHDEBINFO
-    )
-    if(${MSVC_RUNTIME} STREQUAL "static")
-        message(STATUS
-          "MSVC -> forcing use of statically-linked runtime."
-        )
-        foreach(variable ${variables})
-            if(${variable} MATCHES "/MD")
-                string(REGEX REPLACE "/MD" "/MT" ${variable} "${${variable}}")
-            endif()
-        endforeach()
-    else()
-        message(STATUS
-            "MSVC -> forcing use of dynamically-linked runtime."
-        )
-        foreach(variable ${variables})
-            if(${variable} MATCHES "/MT")
-                string(REGEX REPLACE "/MT" "/MD" ${variable} "${${variable}}")
-            endif()
-        endforeach()
-    endif()
-endif ()
+# Use statically linked runtime
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 # Allow creating filters for projects in visual studio.
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,13 +80,19 @@ set_target_properties(libprotoc PROPERTIES FOLDER contrib)
 set_target_properties(protoc PROPERTIES FOLDER contrib)
 set_target_properties(ipv6-parse PROPERTIES FOLDER contrib)
 
+# civetweb's cmake does not set debug postfix
+set_target_properties(civetweb-c-library PROPERTIES DEBUG_POSTFIX "d")
+
 if (MSVC)
+    # Setup MSVC parallelized builds
+    add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
+
     set_target_properties(libprotobuf libprotobuf-lite libprotoc protoc PROPERTIES COMPILE_FLAGS "/W0")
     set_source_files_properties(${libprotobuf_files} PROPERTIES COMPILE_FLAGS "/W0")
     set_source_files_properties(${protobuf_SHARED_OR_STATIC} PROPERTIES COMPILE_FLAGS "/W0")
     set_source_files_properties(${libprotobuf_lite_files} PROPERTIES COMPILE_FLAGS "/W0")
     add_definitions(-D_SCL_SECURE_NO_WARNINGS)
-endif (MSVC)
+endif ()
 
 add_subdirectory("src")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.15)
-cmake_policy(VERSION 3.15)
 
 project(cpp-sc2)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,26 +1,18 @@
-include_directories("../include")
-include_directories("common")
-
-# Setup MSVC parallelized builds
-add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
-
-# Included for all examples
-include_directories(SYSTEM "${PROJECT_BINARY_DIR}/generated")
-include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/contrib/SDL-mirror/include")
-
 # Function to generate an example project with extra libraries
 function (example_project_extra project_name source_code extra_libs)
     message(VERBOSE "Adding new example project ${project_name}, sources: ${source_code}, extra_libs: ${extra_libs}")
     file (GLOB example_project_sources ${source_code} "common/*.h" "common/*.cc")
     add_executable(${project_name} ${example_project_sources})
 
+    target_include_directories(${project_name} PRIVATE "${PROJECT_SOURCE_DIR}/examples/common")
+
     set_target_properties(${project_name} PROPERTIES FOLDER examples)
 
 	if (MSCV AND (NOT (MSVC_VERSION LESS 1910)))
-		target_link_libraries(${project_name} legacy_stdio_definitions)
+		target_link_libraries(${project_name} PRIVATE legacy_stdio_definitions)
 	endif ()
 
-    target_link_libraries(${project_name} sc2api sc2lib sc2utils ${extra_libs})
+    target_link_libraries(${project_name} PRIVATE cpp_sc2 ${extra_libs})
 endfunction ()
 
 # Function to generate a simple example project
@@ -38,7 +30,6 @@ example_project(intermediate_bot "intermediate_bot.cc")
 example_project(annoying_helper "annoying_helper.cc")
 example_project(proxy "proxy.cc")
 example_project(save_load "save_load.cc")
-# example_project(bot_mp_ipv6 "bot_mp_ipv6.cc")
 
 if (BUILD_SC2_RENDERER)
     example_project_extra(feature_layers "feature_layers.cc" sc2renderer)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,115 +1,22 @@
-# All the source files for the sc2 api
-file(GLOB sources_sc2 "sc2api/*.cpp" "sc2api/*.cc" "../include/sc2api/*.h")
-file(GLOB sources_sc2_lib "sc2lib/*.cpp" "sc2lib/*.cc" "../include/sc2lib/*.h")
-file(GLOB sources_utils "sc2utils/*.cpp" "sc2utils/*.cc" "../include/sc2utils/*.h")
-
-# Inject sources specific for particular version of the game client
-file(WRITE "../include/sc2api/sc2_typeenums.h"
-"#pragma once
-
-#include \"typeids/sc2_${SC2_VERSION}_typeenums.h\"
-"
-)
-list(APPEND sources_sc2
-    ../include/sc2api/sc2_typeenums.h
-    ../include/sc2api/typeids/sc2_${SC2_VERSION}_typeenums.h
-    sc2api/typeids/sc2_${SC2_VERSION}_typeenums.cpp
-)
-
-# Gather the protos.
-file(GLOB proto_files
-    "../protocol/s2clientprotocol/*.proto"
-)
-
-if ("${proto_files}" STREQUAL "")
-    message(FATAL_ERROR "Missing root protocol submodule.\nRemove your protocol directory and run:\ngit submodule update --recursive --init")
+if (MSVC)
+    set(CMAKE_CXX_FLAGS_DEBUG "/ZI /Od" CACHE STRING "" FORCE)
+else ()
+    set(CMAKE_CXX_FLAGS "-fpermissive")
 endif ()
 
-# Create the output directory for generated protos.
-file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/generated/s2clientprotocol)
-
-foreach(proto ${proto_files})
-    get_filename_component(proto_name ${proto} NAME_WE)
-    list(APPEND proto_src ${PROJECT_BINARY_DIR}/generated/s2clientprotocol/${proto_name}.pb.h ${PROJECT_BINARY_DIR}/generated/s2clientprotocol/${proto_name}.pb.cc)
-endforeach()
-
-# Now include that directory
-include_directories(SYSTEM "${PROJECT_BINARY_DIR}/generated")
-
-# Setup MSVC parallelized builds
-add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
-
-# Create the library
-add_library(sc2api ${sources_sc2})
-add_library(sc2lib ${sources_sc2_lib})
-add_library(sc2protocol ${proto_src} ${proto_files})
-add_library(sc2utils ${sources_utils})
-
-set_target_properties(sc2api PROPERTIES DEBUG_POSTFIX "d")
-set_target_properties(sc2lib PROPERTIES DEBUG_POSTFIX "d")
-set_target_properties(sc2protocol PROPERTIES DEBUG_POSTFIX "d")
-set_target_properties(sc2utils PROPERTIES DEBUG_POSTFIX "d")
-
-target_link_libraries(sc2protocol libprotobuf)
-
-if (APPLE)
-    target_link_libraries(sc2utils "-framework Carbon")
-endif ()
+add_subdirectory("sc2api")
+add_subdirectory("sc2lib")
+add_subdirectory("sc2utils")
+add_subdirectory("sc2protocol")
 
 if (BUILD_SC2_RENDERER)
-    file(GLOB sources_renderer "sc2renderer/*.cc" "sc2renderer/*.h" "../include/sc2renderer/*.h")
-    add_library(sc2renderer ${sources_renderer})
-
-    if (MSVC)
-        set_target_properties(sc2renderer PROPERTIES COMPILE_FLAGS "/W4 /WX-")
-    endif()
-
-    set_target_properties(sc2renderer PROPERTIES DEBUG_POSTFIX "d")
-
-    include_directories("../contrib/SDL-mirror/include")
-    target_link_libraries(sc2renderer SDL2-static)
+    add_subdirectory("sc2renderer")
 endif ()
 
-# It requires includes to civetweb and our own headers.
-include_directories("../contrib/civetweb/include")
-include_directories("../contrib/SDL-mirror/include")
-include_directories("../contrib/ipv6-parse")
-include_directories("../include")
+add_library(cpp_sc2 INTERFACE)
 
-if (MSVC)
-    set(CMAKE_CXX_FLAGS "/EHsc" CACHE STRING "" FORCE)
-    set(CMAKE_CXX_FLAGS_DEBUG "/MTd /ZI /Od" CACHE STRING "" FORCE)
-    set(CMAKE_CXX_FLAGS_RELEASE "/MT" CACHE STRING "" FORCE)
-
-    set_target_properties(civetweb-c-library PROPERTIES CMAKE_CXX_FLAGS_DEBUG "/MTd")
-    set_target_properties(civetweb-c-library PROPERTIES CMAKE_CXX_FLAGS_RELEASE "/MT")
-else()
-    set(CMAKE_CXX_FLAGS "-fpermissive")
-endif()
-
-add_dependencies(sc2protocol protoc)
-
-foreach (proto ${proto_files})
-    get_filename_component(proto_name ${proto} NAME)
-    get_filename_component(proto_name_we ${proto} NAME_WE)
-    set(outputCC ${PROJECT_BINARY_DIR}/generated/s2clientprotocol/${proto_name_we}.pb.cc)
-    set(outputH ${PROJECT_BINARY_DIR}/generated/s2clientprotocol/${proto_name_we}.pb.h)
-
-    add_custom_command(
-        DEPENDS protoc
-        COMMAND ${PROJECT_BINARY_DIR}/bin/protoc -I=${CMAKE_CURRENT_SOURCE_DIR}/../protocol/ --cpp_out=${PROJECT_BINARY_DIR}/generated ${proto}
-        OUTPUT ${outputCC} ${outputH}
-    )
-
-endforeach()
-
-
-if (MSVC)
-    set_target_properties(sc2api PROPERTIES COMPILE_FLAGS "/W4 /WX-")
-    set_target_properties(sc2lib PROPERTIES COMPILE_FLAGS "/W4 /WX-")
-    set_target_properties(sc2utils PROPERTIES COMPILE_FLAGS "/W3 /WX-")
-    set_target_properties(sc2protocol PROPERTIES COMPILE_FLAGS "/W0")
-endif (MSVC)
-
-target_link_libraries(sc2api sc2protocol civetweb-c-library ipv6-parse)
-target_link_libraries(sc2lib sc2api)
+target_link_libraries(cpp_sc2
+    INTERFACE
+        sc2api
+        sc2lib
+        sc2utils)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,10 +76,6 @@ include_directories("../contrib/SDL-mirror/include")
 include_directories("../contrib/ipv6-parse")
 include_directories("../include")
 
-if(COMMAND cmake_policy)
-    cmake_policy(SET CMP0003 NEW)
-endif(COMMAND cmake_policy)
-
 if (MSVC)
     set(CMAKE_CXX_FLAGS "/EHsc" CACHE STRING "" FORCE)
     set(CMAKE_CXX_FLAGS_DEBUG "/MTd /ZI /Od" CACHE STRING "" FORCE)

--- a/src/sc2api/CMakeLists.txt
+++ b/src/sc2api/CMakeLists.txt
@@ -1,0 +1,36 @@
+# All the source files for the sc2 api
+file(GLOB sources_sc2 "*.cpp" "*.cc" "*.h")
+
+# Inject sources specific for particular version of the game client
+file(WRITE "${PROJECT_SOURCE_DIR}/include/sc2api/sc2_typeenums.h"
+"#pragma once
+
+#include \"typeids/sc2_${SC2_VERSION}_typeenums.h\"
+"
+)
+
+list(APPEND sources_sc2
+    "${PROJECT_SOURCE_DIR}/include/sc2api/sc2_typeenums.h"
+    "${PROJECT_SOURCE_DIR}/include/sc2api/typeids/sc2_${SC2_VERSION}_typeenums.h"
+    "${PROJECT_SOURCE_DIR}/src/sc2api/typeids/sc2_${SC2_VERSION}_typeenums.cpp"
+)
+
+add_library(sc2api ${sources_sc2})
+
+target_include_directories(sc2api
+    PUBLIC
+        "${PROJECT_SOURCE_DIR}/include"
+        "${PROJECT_SOURCE_DIR}/contrib/civetweb/include"
+        "${PROJECT_SOURCE_DIR}/contrib/ipv6-parse")
+
+target_link_libraries(sc2api
+    PUBLIC
+        sc2protocol
+        civetweb-c-library
+        ipv6-parse)
+
+set_target_properties(sc2api PROPERTIES DEBUG_POSTFIX "d")
+
+if (MSVC)
+    set_target_properties(sc2api PROPERTIES COMPILE_FLAGS "/W4 /WX-")
+endif ()

--- a/src/sc2lib/CMakeLists.txt
+++ b/src/sc2lib/CMakeLists.txt
@@ -1,0 +1,11 @@
+file(GLOB sources_sc2_lib "*.cpp" "*.cc" "${PROJECT_SOURCE_DIR}/include/sc2lib/*.h")
+
+add_library(sc2lib ${sources_sc2_lib})
+
+target_link_libraries(sc2lib PRIVATE sc2api)
+
+set_target_properties(sc2lib PROPERTIES DEBUG_POSTFIX "d")
+
+if (MSVC)
+    set_target_properties(sc2lib PROPERTIES COMPILE_FLAGS "/W4 /WX-")
+endif ()

--- a/src/sc2protocol/CMakeLists.txt
+++ b/src/sc2protocol/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Gather the protos.
+file(GLOB proto_files "${PROJECT_SOURCE_DIR}/protocol/s2clientprotocol/*.proto")
+
+if ("${proto_files}" STREQUAL "")
+    message(FATAL_ERROR "Missing root protocol submodule.\nRemove your protocol directory and run:\ngit submodule update --recursive --init")
+endif ()
+
+# Create the output directory for generated protos.
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/generated/s2clientprotocol)
+
+foreach(proto ${proto_files})
+    get_filename_component(proto_name ${proto} NAME_WE)
+    list(APPEND proto_src ${PROJECT_BINARY_DIR}/generated/s2clientprotocol/${proto_name}.pb.h ${PROJECT_BINARY_DIR}/generated/s2clientprotocol/${proto_name}.pb.cc)
+endforeach()
+
+add_library(sc2protocol ${proto_src} ${proto_files})
+add_dependencies(sc2protocol protoc)
+
+target_include_directories(sc2protocol SYSTEM PUBLIC "${PROJECT_BINARY_DIR}/generated")
+
+target_link_libraries(sc2protocol PUBLIC libprotobuf)
+
+set_target_properties(sc2protocol PROPERTIES DEBUG_POSTFIX "d")
+
+foreach (proto ${proto_files})
+    get_filename_component(proto_name ${proto} NAME)
+    get_filename_component(proto_name_we ${proto} NAME_WE)
+    set(outputCC ${PROJECT_BINARY_DIR}/generated/s2clientprotocol/${proto_name_we}.pb.cc)
+    set(outputH ${PROJECT_BINARY_DIR}/generated/s2clientprotocol/${proto_name_we}.pb.h)
+
+    add_custom_command(
+        DEPENDS protoc
+        COMMAND ${PROJECT_BINARY_DIR}/bin/protoc -I=${PROJECT_SOURCE_DIR}/protocol/ --cpp_out=${PROJECT_BINARY_DIR}/generated ${proto}
+        OUTPUT ${outputCC} ${outputH}
+    )
+endforeach()
+
+if (MSVC)
+    set_target_properties(sc2protocol PROPERTIES COMPILE_FLAGS "/W0")
+endif (MSVC)

--- a/src/sc2renderer/CMakeLists.txt
+++ b/src/sc2renderer/CMakeLists.txt
@@ -1,0 +1,16 @@
+file(GLOB sources_renderer "*.cc" "*.h" "${PROJECT_SOURCE_DIR}/include/sc2renderer/*.h")
+
+add_library(sc2renderer ${sources_renderer})
+
+target_include_directories(sc2renderer
+    PRIVATE
+        "${PROJECT_SOURCE_DIR}/contrib/SDL-mirror/include"
+        "${PROJECT_SOURCE_DIR}/include")
+
+target_link_libraries(sc2renderer PRIVATE SDL2-static)
+
+if (MSVC)
+    set_target_properties(sc2renderer PROPERTIES COMPILE_FLAGS "/W4 /WX-")
+endif()
+
+set_target_properties(sc2renderer PROPERTIES DEBUG_POSTFIX "d")

--- a/src/sc2utils/CMakeLists.txt
+++ b/src/sc2utils/CMakeLists.txt
@@ -1,0 +1,15 @@
+file(GLOB sources_utils "*.cpp" "*.cc" "${PROJECT_SOURCE_DIR}/include/sc2utils/*.h")
+
+add_library(sc2utils ${sources_utils})
+
+target_include_directories(sc2utils PRIVATE "${PROJECT_SOURCE_DIR}/include")
+
+set_target_properties(sc2utils PROPERTIES DEBUG_POSTFIX "d")
+
+if (MSVC)
+    set_target_properties(sc2utils PROPERTIES COMPILE_FLAGS "/W3 /WX-")
+endif (MSVC)
+
+if (APPLE)
+    target_link_libraries(sc2utils "-framework Carbon")
+endif ()


### PR DESCRIPTION
My original plan for work on the project was to work on supporting cross-compilation from Linux to Windows in a WSL2 context (using precompiled libraries, xwin for the windows SDK, and Clang) for the BlankBot repository. This would enable users to download a zipped cross-compilation package published by cpp-sc2 and easily build bots from cpp-sc2 in the WSL2 context while using the SC2 executable installed in the windows filesystem.

However, the underlying CMake structure and configuration carried forward from the s2client-api introduces a variety of unexpected side effects which interfered with my original work. I opted to take the time to do a first pass at adjusting the CMake configuration (within reason) to facilitate future development.

There are more changes which *can* be made (e.g. replacing file globbing with explicit source and header file naming, taking a closer look at the remaining compile flags, being more specific to STATIC libraries as dynamic linking was fundamentally broken and should be disabled outright), but I believe this is a good starting point for the purpose of:

- Isolating build logic for each library
- Leveraging CMake's target inheritance scope for includes and linking to simplify the project's configuration
- Replacing old CMake hacks with proper abstractions
- Removing unnecessary and/or repetitious CMake configuration
- General style changes for consistency

I have tested the configuration changes for Debug and Release for:

- Visual Studio 17 2022
- Visual Studio 15 2019
- Visual Studio 15 2017 Win64
- gcc/g++ 9.4.0

I would hope that should this PR be accepted, project documentation can be updated to include support for Visual Studio 17 2022.