### PR TITLE
build: disable ipv6-parse

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "protocol"]
 	path = protocol
 	url = https://github.com/Blizzard/s2client-proto
-[submodule "contrib/ipv6-parse"]
-	path = contrib/ipv6-parse
-	url = https://github.com/jrepp/ipv6-parse
 [submodule "contrib/civetweb"]
 	path = contrib/civetweb
 	url = https://github.com/cpp-sc2/civetweb.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,6 @@ set(CIVETWEB_ENABLE_IPV6 ON CACHE BOOL "" FORCE)
 # Don't build civetweb with sanitizers
 set(CIVETWEB_ENABLE_ASAN OFF CACHE BOOL "" FORCE)
 
-# Settings for ipv6 parse library
-set(IPV6_PARSE_LIBRARY_ONLY ON CACHE BOOL "" FORCE)
-
 # Don't build protobuf tests.
 set(protobuf_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(protobuf_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
@@ -70,15 +67,11 @@ target_compile_options(civetweb-c-library PUBLIC -DUSE_IPV6=1)
 # Run protobufs cmake.
 add_subdirectory("contrib/protobuf/cmake")
 
-# Run ipv6-parse cmake.
-add_subdirectory("contrib/ipv6-parse")
-
 set_target_properties(civetweb-c-library PROPERTIES FOLDER contrib)
 set_target_properties(libprotobuf PROPERTIES FOLDER contrib)
 set_target_properties(libprotobuf-lite PROPERTIES FOLDER contrib)
 set_target_properties(libprotoc PROPERTIES FOLDER contrib)
 set_target_properties(protoc PROPERTIES FOLDER contrib)
-set_target_properties(ipv6-parse PROPERTIES FOLDER contrib)
 
 # civetweb's cmake does not set debug postfix
 set_target_properties(civetweb-c-library PROPERTIES DEBUG_POSTFIX "d")

--- a/src/sc2api/CMakeLists.txt
+++ b/src/sc2api/CMakeLists.txt
@@ -20,14 +20,12 @@ add_library(sc2api ${sources_sc2})
 target_include_directories(sc2api
     PUBLIC
         "${PROJECT_SOURCE_DIR}/include"
-        "${PROJECT_SOURCE_DIR}/contrib/civetweb/include"
-        "${PROJECT_SOURCE_DIR}/contrib/ipv6-parse")
+        "${PROJECT_SOURCE_DIR}/contrib/civetweb/include")
 
 target_link_libraries(sc2api
     PUBLIC
         sc2protocol
-        civetweb-c-library
-        ipv6-parse)
+        civetweb-c-library)
 
 set_target_properties(sc2api PROPERTIES DEBUG_POSTFIX "d")
 


### PR DESCRIPTION
ipv6-parse was introduced as a submodule in [0], but no source files or
dependencies include headers from it. The sole source file which is
likely to have referenced it is the example project source file
bot_mp_ipv6.cc, which has never been added to the project nor enabled
(it has been commented out since it was merged in [1]).

Refs:
    [0] 7286ea4000820a90bc5335b16e881ebec849365f
    [1] https://github.com/cpp-sc2/cpp-sc2/commit/7286ea4000820a90bc5335b16e881ebec849365f#diff-940e5356fa1137e646ea135a6f68cacbfad4fe7124c3a69163468f588acf9283R43