### PR TITLE
Wsl2 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,18 @@
 cmake_minimum_required(VERSION 3.15)
 
+# Skip generating proto files with Protobuf compiler and use prebuilt files
+# Will still build Protobuf as libprotobuf is required for linking
+option(WSL2_CROSS_COMPILE "Building on WSL2 for Windows" OFF)
+
+# Only valid OS configuration should be in WSL2 context
+# Should not work wtih WIN32, APPLE, etc.
+if (WSL2_CROSS_COMPILE AND UNIX AND NOT APPLE)
+    set(CMAKE_TOOLCHAIN_FILE cmake/toolchain/x86-64-w64-mingw32.cmake)
+elseif (WSL2_CROSS_COMPILE)
+    message(FATAL_ERROR "Invalid environment.\
+                        WSL2_CROSS_COMPILE=ON for WSL only")
+endif ()
+
 project(cpp-sc2)
 
 include(FetchContent)
@@ -33,7 +46,9 @@ set(LIBRARY_DEBUG_POSTFIX d)
 set(CMAKE_DEBUG_POSTFIX ${LIBRARY_DEBUG_POSTFIX})
 
 # External subprojects
-list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/thirdparty/cmake")
+list(APPEND CMAKE_MODULE_PATH
+    "${PROJECT_SOURCE_DIR}/thirdparty/cmake"
+    "${PROJECT_SOURCE_DIR}/cmake/assets")
 
 # Build with c++14 support.
 set(CMAKE_CXX_STANDARD 14)
@@ -55,6 +70,10 @@ endif ()
 
 if (BUILD_API_TESTS)
     add_subdirectory(tests)
+endif ()
+
+if (WSL2_CROSS_COMPILE)
+    include(protos)
 endif ()
 
 # External subproject depedencies

--- a/cmake/assets/protos.cmake
+++ b/cmake/assets/protos.cmake
@@ -1,0 +1,9 @@
+message(STATUS "FetchContent: generated protos for Windows")
+
+FetchContent_Declare(
+    protos
+    URL https://storage.yandexcloud.net/cpp-sc2/wsl2/generated-s2clientprotocol-db14236-protobuf-1a74ba4.zip
+    URL_HASH MD5=346e3d8127f2da6cea4900465183314b
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+)
+FetchContent_MakeAvailable(protos)

--- a/cmake/toolchain/x86-64-w64-mingw32.cmake
+++ b/cmake/toolchain/x86-64-w64-mingw32.cmake
@@ -1,0 +1,19 @@
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86)
+
+# Cross compilation option to pass CMake checks
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+set(CMAKE_FIND_ROOT_PATH /usr/x86_64-w64-mingw32)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+# See SO for POSIX alternative requirements
+# https://stackoverflow.com/questions/14191566/c-mutex-in-namespace-std-does-not-name-a-type
+set(CMAKE_C_COMPILER /usr/bin/x86_64-w64-mingw32-gcc)
+set(CMAKE_CXX_COMPILER /usr/bin/x86_64-w64-mingw32-g++)
+
+set(CMAKE_CXX_FLAGS "--static -static-libgcc -static-libstdc++")

--- a/src/sc2api/sc2_connection.cc
+++ b/src/sc2api/sc2_connection.cc
@@ -8,7 +8,9 @@
 
 #include "civetweb.h"
 
-#if defined (_WIN32)
+#if defined (_WIN32) && defined(__MINGW32__)
+#include <winsock2.h>
+#elif defined (_WIN32)
 #include <WinSock2.h>
 #endif
 

--- a/src/sc2protocol/CMakeLists.txt
+++ b/src/sc2protocol/CMakeLists.txt
@@ -21,7 +21,7 @@ foreach(proto ${proto_files})
             "${proto_generation_dir}/${proto_name}.pb.h")
 endforeach()
 
-add_library(sc2protocol STATIC ${proto_src} ${proto_files})
+add_library(sc2protocol STATIC ${proto_src})
 
 target_include_directories(sc2protocol SYSTEM PUBLIC "${PROJECT_BINARY_DIR}/generated")
 
@@ -31,21 +31,35 @@ if (MSVC)
     target_compile_options(sc2protocol PRIVATE /W0)
 endif (MSVC)
 
-foreach (proto ${proto_files})
-    get_filename_component(proto_name_we ${proto} NAME_WE)
-    set(protoc_out_cc "${proto_generation_dir}/${proto_name_we}.pb.cc")
-    set(protoc_out_h "${proto_generation_dir}/${proto_name_we}.pb.h")
+# Copy precompiled protos to the generated directory
+if (WSL2_CROSS_COMPILE)
+    foreach (proto ${proto_files})
+        get_filename_component(proto_name ${proto} NAME_WE)
+        file(
+            COPY
+                "${protos_SOURCE_DIR}/${proto_name}.pb.h"
+                "${protos_SOURCE_DIR}/${proto_name}.pb.cc"
+            DESTINATION
+                "${proto_generation_dir}")
+    endforeach ()
+# Compile protos with protoc
+else ()
+    foreach (proto ${proto_files})
+        get_filename_component(proto_name_we ${proto} NAME_WE)
+        set(protoc_out_cc "${proto_generation_dir}/${proto_name_we}.pb.cc")
+        set(protoc_out_h "${proto_generation_dir}/${proto_name_we}.pb.h")
 
-    add_custom_command(
-        OUTPUT
-            "${protoc_out_cc}"
-            "${protoc_out_h}"
-        COMMAND
-            "${PROJECT_BINARY_DIR}/bin/protoc"
-            "-I=${sc2protocol_SOURCE_DIR}"
-            "--cpp_out=${PROJECT_BINARY_DIR}/generated"
-            "${proto}"
-        DEPENDS protoc
-        VERBATIM
-    )
-endforeach()
+        add_custom_command(
+            OUTPUT
+                "${protoc_out_cc}"
+                "${protoc_out_h}"
+            COMMAND
+                "${PROJECT_BINARY_DIR}/bin/protoc"
+                "-I=${sc2protocol_SOURCE_DIR}"
+                "--cpp_out=${PROJECT_BINARY_DIR}/generated"
+                "${proto}"
+            DEPENDS protoc
+            VERBATIM
+        )
+    endforeach()
+endif ()

--- a/thirdparty/cmake/protobuf.cmake
+++ b/thirdparty/cmake/protobuf.cmake
@@ -3,6 +3,11 @@ message(STATUS "FetchContent: protobuf")
 set(protobuf_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(protobuf_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 
+# Do not build Protobuf compiler if using precompiled proto files
+if (WSL2_CROSS_COMPILE)
+    set(protobuf_BUILD_PROTOC_BINARIES OFF CACHE BOOL "" FORCE)
+endif ()
+
 FetchContent_Declare(
     protobuf
     GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git


### PR DESCRIPTION
Opening a PR to demonstrate current approach, but not ready for merge.

TODOs include:
- Build documentation updates
- A central archive of precompiled `pb.cc` and `pb.h` protos for Windows to fetch from
- Some cleanup in the `CMakeLists.txt` file for sc2protocol, as it is currently just copying the downloaded files into `generated/s2clientprotocol`. Should conditionally use the downloaded files correctly, but requires some refinement on how paths are being set.