### PR TITLE
fix: sdl fetchcontent case sensitive fix

### DIFF
--- a/src/sc2renderer/CMakeLists.txt
+++ b/src/sc2renderer/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(sc2renderer STATIC ${sc2renderer_sources})
 set_target_properties(sc2renderer PROPERTIES FOLDER utilities)
 
 target_include_directories(sc2renderer PRIVATE "${PROJECT_SOURCE_DIR}/include")
-target_include_directories(sc2renderer SYSTEM PRIVATE "${SDL_SOURCE_DIR}/include")
+target_include_directories(sc2renderer SYSTEM PRIVATE "${sdl_SOURCE_DIR}/include")
 
 target_link_libraries(sc2renderer PRIVATE SDL2-static)
 

--- a/thirdparty/cmake/SDL.cmake
+++ b/thirdparty/cmake/SDL.cmake
@@ -7,11 +7,11 @@ set(SDL2_DISABLE_UNINSTALL ON CACHE BOOL "" FORCE)
 set(SDL2_DISABLE_SDL2MAIN ON CACHE BOOL "" FORCE)
 
 FetchContent_Declare(
-    SDL
+    sdl
     GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
     GIT_TAG bdc7f958fda50305744dcefdccac29373da97d01
 )
-FetchContent_MakeAvailable(SDL)
+FetchContent_MakeAvailable(sdl)
 
 # IDE folders
 set_target_properties(SDL2-static PROPERTIES FOLDER contrib)


### PR DESCRIPTION
Uppercase SDL in SDL_SOURCE_DIR would not resolve - either a
FetchContent or general CMake implementation detail.