### PR TITLE
build: cmake policy setting for protos download

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.15)
 
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+    cmake_policy(SET CMP0135 NEW)
+endif ()
+
 # Skip generating proto files with Protobuf compiler and use prebuilt files
 # Will still build Protobuf as libprotobuf is required for linking
 option(WSL2_CROSS_COMPILE "Building on WSL2 for Windows" OFF)

--- a/cmake/assets/protos.cmake
+++ b/cmake/assets/protos.cmake
@@ -4,6 +4,5 @@ FetchContent_Declare(
     protos
     URL https://storage.yandexcloud.net/cpp-sc2/wsl2/generated-s2clientprotocol-db14236-protobuf-1a74ba4.zip
     URL_HASH MD5=346e3d8127f2da6cea4900465183314b
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
 FetchContent_MakeAvailable(protos)


### PR DESCRIPTION
CMake version 3.24 and newer will raise a warning regarding URL
downloads with ExternalProject_Add (and by extension
FetchContent_Declare). Use a pinned policy for forward versions in lieu
of moving the minimum required version.