### PR TITLE
Civetweb and sc2_connection improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set(CMAKE_DEBUG_POSTFIX ${LIBRARY_DEBUG_POSTFIX})
 # External subprojects
 list(APPEND CMAKE_MODULE_PATH
     "${PROJECT_SOURCE_DIR}/thirdparty/cmake"
+    "${PROJECT_SOURCE_DIR}/thirdparty/civetweb"
     "${PROJECT_SOURCE_DIR}/cmake/assets")
 
 # Build with c++14 support.

--- a/src/sc2api/sc2_client.cc
+++ b/src/sc2api/sc2_client.cc
@@ -1472,6 +1472,7 @@ bool ControlImp::Connect(const std::string& address, int port, int timeout_ms) {
         timeout_seconds = 1;
     }
 
+    std::cout << "Connecting to " << address << ":" << port << "...\n";
 
     for (unsigned int count_seconds = 0; count_seconds < timeout_seconds; ++count_seconds) {
         if (proto_.ConnectToGame(address, port, timeout_ms)) {
@@ -1479,17 +1480,10 @@ bool ControlImp::Connect(const std::string& address, int port, int timeout_ms) {
             break;
         }
         SleepFor(1000);
-
-        if (count_seconds == 0) {
-            std::cout << "Waiting for connection";
-        } else {
-            std::cout << ".";
-        }
     }
-    std::cout << std::endl;
 
     if (!connected) {
-        std::cerr << "Unable to connect to game" << std::endl;
+        std::cerr << "Unable to connect to game\n";
         return false;
     }
 

--- a/src/sc2api/sc2_connection.cc
+++ b/src/sc2api/sc2_connection.cc
@@ -106,14 +106,14 @@ bool Connection::Connect(const std::string& address, int port, bool verbose) {
     StartCivetweb();
     verbose_ = verbose;
 
-    char ebuff[100] = { 0 };
+    char ebuff[256] = { 0 };
 
     connection_ = mg_connect_websocket_client(
         address.c_str(),
         port,
         0,
         ebuff,
-        100,
+        256,
         "/sc2api",
         nullptr,
         DataHandler,
@@ -121,6 +121,7 @@ bool Connection::Connect(const std::string& address, int port, bool verbose) {
         (void*) this);
 
     if (!connection_) {
+        std::cerr << "Failed to establish websocket connection: " << ebuff << std::endl;
         return false;
     }
 

--- a/src/sc2api/sc2_connection.cc
+++ b/src/sc2api/sc2_connection.cc
@@ -8,43 +8,50 @@
 
 #include "civetweb.h"
 
-#if defined (_WIN32) && defined(__MINGW32__)
-#include <winsock2.h>
-#elif defined (_WIN32)
-#include <WinSock2.h>
-#endif
-
-namespace sc2 {
-
-void StartCivetweb() {
+namespace {
+bool StartCivetweb() {
     static bool is_initialized = false;
-    static const char* REQUEST_TIMEOUT_MS = "5000";
-    static const char* WEBSOCKET_TIMEOUT_MS = "1200000";
-    static const char* NUM_THREADS = "4";
-    static const char* NO_DELAY = "1";
 
     if (is_initialized) {
-        return;
+        return true;
     }
 
     const char* options[] = {
         "request_timeout_ms",
-        REQUEST_TIMEOUT_MS,
+        "5000",
         "websocket_timeout_ms",
-        WEBSOCKET_TIMEOUT_MS,
+        "1200000",
         "num_threads",
-        NUM_THREADS,
+        "4",
         "tcp_nodelay",
-        NO_DELAY,
+        "1",
         0
     };
 
-    mg_callbacks callbacks;
-    memset(&callbacks, 0, sizeof(callbacks));
-    mg_start(&callbacks, nullptr, options);
+    struct mg_callbacks callbacks = {0};
+
+    struct mg_init_data mg_start_init_data = {0};
+    mg_start_init_data.callbacks = &callbacks;
+    mg_start_init_data.configuration_options = options;
+
+    struct mg_error_data mg_start_error_data = {0};
+    char ebuff[256] = {0};
+    mg_start_error_data.text = ebuff;
+    mg_start_error_data.text_buffer_size = sizeof(ebuff);
+
+    const auto* ctx = mg_start2(&mg_start_init_data, &mg_start_error_data);
+    if (!ctx) {
+        std::cerr << "Failed to start civetweb server: " << ebuff << std::endl;
+        return false;
+    }
 
     is_initialized = true;
+    return true;
 }
+
+}  // anonymous namespace
+
+namespace sc2 {
 
 bool GetClientData(const mg_connection* connection, sc2::Connection*& out) {
     if (!connection) {
@@ -101,12 +108,13 @@ Connection::Connection() :
     condition_(),
     has_response_(false) {}
 
-
 bool Connection::Connect(const std::string& address, int port, bool verbose) {
-    StartCivetweb();
+    if (!StartCivetweb()) {
+        return false;
+    }
     verbose_ = verbose;
 
-    char ebuff[256] = { 0 };
+    char ebuff[256] = {0};
 
     connection_ = mg_connect_websocket_client(
         address.c_str(),

--- a/thirdparty/civetweb/0001-Setting-TCP_NODELAY-on-outbound-connections.patch
+++ b/thirdparty/civetweb/0001-Setting-TCP_NODELAY-on-outbound-connections.patch
@@ -1,0 +1,39 @@
+From 44b561e5119151454b9572cbe75af622bb929b90 Mon Sep 17 00:00:00 2001
+From: Jacob Repp <jacobrepp@gmail.com>
+Date: Tue, 21 Nov 2017 16:16:31 -0800
+Subject: [PATCH 1/2] Setting TCP_NODELAY on outbound connections
+
+---
+ src/civetweb.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/civetweb.c b/src/civetweb.c
+index 1e28e649..bded168b 100644
+--- a/src/civetweb.c
++++ b/src/civetweb.c
+@@ -101,6 +101,8 @@
+ #pragma warning(disable : 4306)
+ /* conditional expression is constant: introduced by FD_SET(..) */
+ #pragma warning(disable : 4127)
++/* expression before comma has no effect; expected expression with side-effect: introduced by FD_SET in VC2017 */
++#pragma warning(disable : 4548)
+ /* non-constant aggregate initializer: issued due to missing C99 support */
+ #pragma warning(disable : 4204)
+ /* padding added after data member */
+@@ -9407,6 +9409,13 @@ connect_socket(
+ 		return 0;
+ 	}
+ 
++	int nodelay_on = 1;
++	setsockopt(*sock,
++		IPPROTO_TCP,
++		TCP_NODELAY,
++		(SOCK_OPT_TYPE)&nodelay_on,
++		sizeof(nodelay_on));
++
+ 	set_close_on_exec(*sock, NULL, ctx);
+ 
+ 	if (ip_ver == 4) {
+-- 
+2.39.3 (Apple Git-145)
+

--- a/thirdparty/civetweb/0002-Moving-include-CTest-into-if-testing-guard.patch
+++ b/thirdparty/civetweb/0002-Moving-include-CTest-into-if-testing-guard.patch
@@ -1,0 +1,28 @@
+From 61fc8f811acb3da60d313d5459aa93c9e85fe32c Mon Sep 17 00:00:00 2001
+From: Jacob Repp <jacobrepp@gmail.com>
+Date: Tue, 21 Nov 2017 16:26:45 -0800
+Subject: [PATCH 2/2] Moving include(CTest) into 'if testing' guard
+
+---
+ CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6a37d732..02a55aeb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -559,8 +559,10 @@ endif()
+ add_subdirectory(src)
+ 
+ # Enable the testing of the library/executable
+-include(CTest)
++
+ if (CIVETWEB_BUILD_TESTING)
++  include(CTest)
++
+   # Check unit testing framework Version
+   set(CIVETWEB_CHECK_VERSION 0.11.0 CACHE STRING
+     "The version of Check unit testing framework to build and include statically")
+-- 
+2.39.3 (Apple Git-145)
+

--- a/thirdparty/civetweb/civetweb.cmake
+++ b/thirdparty/civetweb/civetweb.cmake
@@ -13,10 +13,19 @@ set(CIVETWEB_ENABLE_WEBSOCKETS ON CACHE BOOL "" FORCE)
 # Disable IPv6 as we use only IPv4
 set(CIVETWEB_ENABLE_IPV6 OFF CACHE BOOL "" FORCE)
 
+# Apply source code tweaks
+set(workdir "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/civetweb")
+set(civetweb_patches
+    "${CMAKE_CURRENT_LIST_DIR}/0001-Setting-TCP_NODELAY-on-outbound-connections.patch"
+    "${CMAKE_CURRENT_LIST_DIR}/0002-Moving-include-CTest-into-if-testing-guard.patch"
+)
+set(patch_executor git apply --ignore-whitespace ${civetweb_patches})
+
 FetchContent_Declare(
     civetweb
-    GIT_REPOSITORY https://github.com/cpp-sc2/civetweb.git
-    GIT_TAG 61fc8f811acb3da60d313d5459aa93c9e85fe32c
+    GIT_REPOSITORY https://github.com/civetweb/civetweb.git
+    GIT_TAG 1fb204ecc630515d53291f58955c799785cb90c7
+    PATCH_COMMAND ${patch_executor}
 )
 FetchContent_MakeAvailable(civetweb)
 


### PR DESCRIPTION
This improvement allows to avoid usage of custom civetweb fork. Now all patches are kept in the main repository so we can use upstream directly.