### PR TITLE
feat: Update CMakeLists for Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,9 @@ if (MSVC)
 
     # Use statically linked runtime
     set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>)
+
+    # Set startup project in Visual Studio
+    set_property( DIRECTORY PROPERTY VS_STARTUP_PROJECT all_tests)
 endif ()
 
 if (BUILD_API_EXAMPLES)

--- a/src/sc2api/CMakeLists.txt
+++ b/src/sc2api/CMakeLists.txt
@@ -26,7 +26,35 @@ set(sc2api_sources
     sc2_unit.cc
     "typeids/sc2_${SC2_VERSION}_typeenums.cpp")
 
-add_library(sc2api STATIC ${sc2api_sources})
+set(header_path "${PROJECT_SOURCE_DIR}/include/sc2api/")
+set(sc2api_headers
+    ${header_path}/sc2_action.h
+    ${header_path}/sc2_agent.h
+    ${header_path}/sc2_api.h
+    ${header_path}/sc2_args.h
+    ${header_path}/sc2_client.h
+    ${header_path}/sc2_common.h
+    ${header_path}/sc2_connection.h
+    ${header_path}/sc2_control_interfaces.h
+    ${header_path}/sc2_coordinator.h
+    ${header_path}/sc2_data.h
+    ${header_path}/sc2_errors.h
+    ${header_path}/sc2_gametypes.h
+    ${header_path}/sc2_game_settings.h
+    ${header_path}/sc2_interfaces.h
+    ${header_path}/sc2_map_info.h
+    ${header_path}/sc2_proto_interface.h
+    ${header_path}/sc2_proto_to_pods.h
+    ${header_path}/sc2_replay_observer.h
+    ${header_path}/sc2_score.h
+    ${header_path}/sc2_server.h
+    ${header_path}/sc2_typeenums.h
+    ${header_path}/sc2_types.h
+    ${header_path}/sc2_unit.h
+    ${header_path}/sc2_unit_filters.h
+    "${header_path}/typeids/sc2_${SC2_VERSION}_typeenums.h")
+
+add_library(sc2api STATIC ${sc2api_sources} ${sc2api_headers})
 
 target_include_directories(sc2api PUBLIC "${PROJECT_SOURCE_DIR}/include")
 target_include_directories(sc2api SYSTEM PUBLIC "${civetweb_SOURCE_DIR}/include")

--- a/src/sc2lib/CMakeLists.txt
+++ b/src/sc2lib/CMakeLists.txt
@@ -2,7 +2,13 @@ set(sc2lib_sources
     sc2_search.cc
     sc2_utils.cc)
 
-add_library(sc2lib STATIC ${sc2lib_sources})
+set(header_path "${PROJECT_SOURCE_DIR}/include/sc2lib/")
+set(sc2lib_headers
+    ${header_path}/sc2_lib.h
+    ${header_path}/sc2_search.h
+    ${header_path}/sc2_utils.h)
+
+add_library(sc2lib STATIC ${sc2lib_sources} ${sc2lib_headers})
 
 target_link_libraries(sc2lib PRIVATE sc2api)
 

--- a/src/sc2renderer/CMakeLists.txt
+++ b/src/sc2renderer/CMakeLists.txt
@@ -1,6 +1,9 @@
 set(sc2renderer_sources sc2_renderer.cc)
 
-add_library(sc2renderer STATIC ${sc2renderer_sources})
+set(header_path "${PROJECT_SOURCE_DIR}/include/sc2renderer/")
+set(sc2renderer_headers ${header_path}/sc2_renderer.h)
+
+add_library(sc2renderer STATIC ${sc2renderer_sources} ${sc2renderer_headers})
 
 set_target_properties(sc2renderer PROPERTIES FOLDER utilities)
 

--- a/src/sc2utils/CMakeLists.txt
+++ b/src/sc2utils/CMakeLists.txt
@@ -4,7 +4,15 @@ set(sc2utils_sources
     sc2_property_reader.cc
     sc2_scan_directory.cc)
 
-add_library(sc2utils STATIC ${sc2utils_sources})
+set(header_path "${PROJECT_SOURCE_DIR}/include/sc2utils/")
+set(sc2utils_headers
+    ${header_path}/sc2_arg_parser.h
+    ${header_path}/sc2_manage_process.h
+    ${header_path}/sc2_property_reader.h
+    ${header_path}/sc2_scan_directory.h
+    ${header_path}/sc2_simple_serialization.h)
+
+add_library(sc2utils STATIC ${sc2utils_sources} ${sc2utils_headers})
 
 target_include_directories(sc2utils PRIVATE "${PROJECT_SOURCE_DIR}/include")
 


### PR DESCRIPTION
Added include sources to cmake, needed for "header" and "source" folders to show up in Visual Studio Solution Explorer.
Also added debug arguments, so one can simply hit "Windows Debugger" in the IDE, to get the tests to run.  
Hopefully will make troubleshooting Windows installs easier, by not having to manually set these defaults.

Open to any changes/suggestions.