### PR TITLE
docs: Update linux build instructions

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -76,7 +76,9 @@ $ cd cpp-sc2
 $ cmake -B build
 
 # Build the project.
-$ cmake --build build --parallel
+$ cmake --build build --parallel $(nproc --ignore=0)
+
+# If building freezes in above step, increase number: --ignore=1, ignore=2 ...
 ```
 
 ## Linux (cmdline)
@@ -91,7 +93,9 @@ $ cd cpp-sc2
 $ cmake -B build
 
 # Build the project.
-$ cmake --build build --parallel
+$ cmake --build build --parallel $(nproc --ignore=0)
+
+# If building freezes in above step, increase number: --ignore=1, ignore=2 ...
 ```
 
 ## Compilation options


### PR DESCRIPTION
Building protobuf with '--parallel' parameter causes computer to freeze and shell to crash. 
Using 'n-1' threads that your cpu supports seems to avoid google crashing the shell.

Tried building protobuf outside the project with '--parallel' and it broke similar place as in our project.

closes #141 
