### PR TITLE
build: Link precompiled protobuf compiler (protoc) for WSL builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,7 @@ set(CMAKE_DEBUG_POSTFIX ${LIBRARY_DEBUG_POSTFIX})
 # External subprojects
 list(APPEND CMAKE_MODULE_PATH
     "${PROJECT_SOURCE_DIR}/thirdparty/cmake"
-    "${PROJECT_SOURCE_DIR}/thirdparty/civetweb"
-    "${PROJECT_SOURCE_DIR}/cmake/assets")
+    "${PROJECT_SOURCE_DIR}/thirdparty/civetweb")
 
 # Build with c++17 support.
 set(CMAKE_CXX_STANDARD 17)
@@ -75,10 +74,6 @@ endif ()
 
 if (BUILD_API_TESTS)
     add_subdirectory(tests)
-endif ()
-
-if (WSL2_CROSS_COMPILE)
-    include(protos)
 endif ()
 
 # External subproject depedencies

--- a/cmake/assets/protos.cmake
+++ b/cmake/assets/protos.cmake
@@ -1,8 +1,0 @@
-message(STATUS "FetchContent: generated protos for Windows")
-
-FetchContent_Declare(
-    protos
-    URL https://storage.yandexcloud.net/cpp-sc2/wsl2/generated-s2clientprotocol-db14236-protobuf-1a74ba4.zip
-    URL_HASH MD5=346e3d8127f2da6cea4900465183314b
-)
-FetchContent_MakeAvailable(protos)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -30,6 +30,7 @@ example_project(intermediate_bot intermediate_bot.cc)
 example_project(annoying_helper annoying_helper.cc)
 example_project(proxy proxy.cc)
 example_project(save_load save_load.cc)
+example_project(bot_wsl bot_wsl.cc)
 
 if (BUILD_SC2_RENDERER)
     example_project_extra(feature_layers feature_layers.cc sc2renderer)

--- a/examples/bot_wsl.cc
+++ b/examples/bot_wsl.cc
@@ -1,0 +1,67 @@
+#include <iostream>
+
+#include "sc2api/sc2_api.h"
+#include "sc2lib/sc2_lib.h"
+#include "sc2utils/sc2_manage_process.h"
+
+class FooBot : public sc2::Agent {
+public:
+    uint32_t restarts_;
+
+    FooBot() : restarts_(0) {
+    }
+
+    virtual void OnGameStart() final {
+        std::cout << "Starting a new game (" << restarts_ << " restarts)" << std::endl;
+    };
+
+    virtual void OnStep() final {
+        uint32_t game_loop = Observation()->GetGameLoop();
+
+        if (game_loop % 100 == 0) {
+            sc2::Units units = Observation()->GetUnits(sc2::Unit::Alliance::Self);
+            for (auto& it_unit : units) {
+                sc2::Point2D target = sc2::FindRandomLocation(Observation()->GetGameInfo());
+                Actions()->UnitCommand(it_unit, sc2::ABILITY_ID::SMART, target);
+            }
+        }
+    };
+
+    virtual void OnGameEnd() final {
+        ++restarts_;
+        std::cout << "Game ended after: " << Observation()->GetGameLoop() << " loops " << std::endl;
+    };
+
+private:
+};
+
+//*************************************************************************************************
+int main(int argc, char* argv[]) {
+    sc2::Coordinator coordinator;
+    if (!coordinator.LoadSettings(argc, argv)) {
+        return 1;
+    }
+
+    // Add the custom bot, it will control the players.
+    FooBot bot;
+
+    coordinator.SetParticipants({CreateParticipant(sc2::Race::Terran, &bot), CreateComputer(sc2::Race::Terran)});
+
+    // Start the game.
+    coordinator.LaunchStarcraft();
+
+    // Step forward the game simulation.
+    bool do_break = false;
+    while (!do_break) {
+        // Enter name of map found in path:
+        // "C:\Program Files (x86)\StarCraft II\Maps\"
+        coordinator.StartGame("Belshir.SC2Map");
+        while (coordinator.Update() && !do_break) {
+            if (sc2::PollKeyPress()) {
+                do_break = true;
+            }
+        }
+    }
+
+    return 0;
+}

--- a/src/sc2protocol/CMakeLists.txt
+++ b/src/sc2protocol/CMakeLists.txt
@@ -14,12 +14,12 @@ set(proto_files
 set(proto_generation_dir "${PROJECT_BINARY_DIR}/generated/s2clientprotocol")
 file(MAKE_DIRECTORY "${proto_generation_dir}")
 
-foreach(proto ${proto_files})
+foreach (proto ${proto_files})
     get_filename_component(proto_name ${proto} NAME_WE)
     list(APPEND proto_src
             "${proto_generation_dir}/${proto_name}.pb.cc"
             "${proto_generation_dir}/${proto_name}.pb.h")
-endforeach()
+endforeach ()
 
 add_library(sc2protocol STATIC ${proto_src})
 
@@ -31,24 +31,24 @@ if (MSVC)
     target_compile_options(sc2protocol PRIVATE /W0)
 endif (MSVC)
 
-# Copy precompiled protos to the generated directory
-if (WSL2_CROSS_COMPILE)
-    foreach (proto ${proto_files})
-        get_filename_component(proto_name ${proto} NAME_WE)
-        file(
-            COPY
-                "${protos_SOURCE_DIR}/${proto_name}.pb.h"
-                "${protos_SOURCE_DIR}/${proto_name}.pb.cc"
-            DESTINATION
-                "${proto_generation_dir}")
-    endforeach ()
-# Compile protos with protoc
-else ()
-    foreach (proto ${proto_files})
-        get_filename_component(proto_name_we ${proto} NAME_WE)
-        set(protoc_out_cc "${proto_generation_dir}/${proto_name_we}.pb.cc")
-        set(protoc_out_h "${proto_generation_dir}/${proto_name_we}.pb.h")
-
+# Compile the proto files
+foreach (proto ${proto_files})
+    get_filename_component(proto_name_we ${proto} NAME_WE)
+    set(protoc_out_cc "${proto_generation_dir}/${proto_name_we}.pb.cc")
+    set(protoc_out_h "${proto_generation_dir}/${proto_name_we}.pb.h")
+    if (WSL2_CROSS_COMPILE) 
+        add_custom_command(
+            OUTPUT
+                "${protoc_out_cc}"
+                "${protoc_out_h}"
+            COMMAND
+                "${PROJECT_BINARY_DIR}/_deps/protos-src/bin/protoc"
+                "-I=${sc2protocol_SOURCE_DIR}"
+                "--cpp_out=${PROJECT_BINARY_DIR}/generated"
+                "${proto}"
+            VERBATIM
+            )
+    else ()
         add_custom_command(
             OUTPUT
                 "${protoc_out_cc}"
@@ -61,5 +61,5 @@ else ()
             DEPENDS protoc
             VERBATIM
         )
-    endforeach()
-endif ()
+    endif ()
+endforeach ()

--- a/thirdparty/cmake/protobuf.cmake
+++ b/thirdparty/cmake/protobuf.cmake
@@ -3,7 +3,7 @@ message(STATUS "FetchContent: protobuf")
 set(protobuf_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(protobuf_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 
-# Do not build Protobuf compiler if using precompiled proto files
+# Cross compiling causes protoc to be built for target (Windows)
 if (WSL2_CROSS_COMPILE)
     set(protobuf_BUILD_PROTOC_BINARIES OFF CACHE BOOL "" FORCE)
 endif ()
@@ -15,7 +15,19 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(protobuf)
 
-set(protobuf_targets libprotobuf libprotobuf-lite libprotoc protoc)
+if (WSL2_CROSS_COMPILE)
+    message(STATUS "FetchContent: pre-compiled protoc binary for WSL")
+    # This must version match protobuf GIT_TAG above, or will generate runtime errors.
+    FetchContent_Declare(
+        protos
+        URL https://github.com/protocolbuffers/protobuf/releases/download/v23.4/protoc-23.4-linux-x86_64.zip
+    )
+    FetchContent_MakeAvailable(protos)
+    set(protobuf_targets libprotobuf libprotobuf-lite libprotoc)
+
+else ()
+    set(protobuf_targets libprotobuf libprotobuf-lite libprotoc protoc)
+endif ()
 
 foreach (target IN LISTS protobuf_targets)
     if (TARGET ${target})


### PR DESCRIPTION
Fixes build issue with WSL.  Links directly to protoc binary in protobuf github.  Eliminates need to update compiled asset.  
Important: protobuf and protoc version must match.

Closes issue #143 as-is, but still doesn't fix port mismatch/negotiation error with ladder.
Unable to chase that error down, effort concentrated on making docker dev environment to make error more easily reproducible. 
https://github.com/Nickrader/blank-bot/tree/dev_docker
