### PR TITLE
Fix 3 proto : pod conversion bugs + bump sc2protocol pin

### DIFF
--- a/src/sc2api/sc2_data.cc
+++ b/src/sc2api/sc2_data.cc
@@ -122,7 +122,7 @@ void AbilityData::ReadFromProto(const SC2APIProtocol::AbilityData& ability_data)
 
     is_instant_placement = false;
     if (ability_data.has_is_instant_placement()) {
-        is_instant_placement = ability_data.has_is_instant_placement();
+        is_instant_placement = ability_data.is_instant_placement();
     }
 
     cast_range = 0.0f;

--- a/src/sc2api/sc2_proto_to_pods.cc
+++ b/src/sc2api/sc2_proto_to_pods.cc
@@ -97,7 +97,7 @@ bool Convert(const ScorePtr& score_ptr, ScoreDetails& score_details) {
         Convert(score_details_ptr->total_damage_dealt(), score_details.total_damage_dealt);
     }
 
-    if (score_details_ptr->has_collected_minerals()) {
+    if (score_details_ptr->has_total_damage_taken()) {
         Convert(score_details_ptr->total_damage_taken(), score_details.total_damage_taken);
     }
 

--- a/src/sc2api/sc2_proto_to_pods.cc
+++ b/src/sc2api/sc2_proto_to_pods.cc
@@ -44,6 +44,7 @@ bool Convert(const ScorePtr& score_ptr, ScoreDetails& score_details) {
     score_details.killed_value_units = score_details_ptr->killed_value_units();
     score_details.killed_value_structures = score_details_ptr->killed_value_structures();
     score_details.collected_minerals = score_details_ptr->collected_minerals();
+    score_details.collected_vespene = score_details_ptr->collected_vespene();
     score_details.collection_rate_minerals = score_details_ptr->collection_rate_minerals();
     score_details.collection_rate_vespene = score_details_ptr->collection_rate_vespene();
     score_details.spent_minerals = score_details_ptr->spent_minerals();

--- a/thirdparty/cmake/sc2protocol.cmake
+++ b/thirdparty/cmake/sc2protocol.cmake
@@ -3,7 +3,7 @@ message(STATUS "FetchContent: protocol")
 FetchContent_Declare(
     sc2protocol
     GIT_REPOSITORY https://github.com/Blizzard/s2client-proto.git
-    GIT_TAG c04df4adbe274858a4eb8417175ee32ad02fd609
+    GIT_TAG bff45dae1fc685e6acbaae084670afb7d1c0832c
     GIT_PROGRESS TRUE
 )
 FetchContent_MakeAvailable(sc2protocol)


### PR DESCRIPTION
## Bugs fixed

- `ScoreDetails::collected_vespene` was never set in proto→pod (always 0). `sc2_proto_to_pods.cc`
- `total_damage_taken` gated by `has_collected_minerals()` instead of `has_total_damage_taken()`, value lost when minerals field absent. `sc2_proto\
_to_pods.cc:100`
- `AbilityData::is_instant_placement` assigned `has_is_instant_placement()` (presence) instead of the actual value, always true when field present.\
 `sc2_data.cc:125`

## Infra

- Bump sc2protocol pin `c04df4a` → `bff45da` (v5.0.12 → v5.0.15). Byte-identical .proto + stableid.json, only version string differs.
- Bump civetweb v1.15 → `dfdfdb6` and protobuf v3.23.4 → v33.0 for CMake v4 compatibility (mirrors upstream commit `349f451` from v +2.1.0, #153).