### PR TITLE
Bundled fixes, missing proto-field exposures, and doctest unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(FETCHCONTENT_QUIET FALSE)
 option(BUILD_SC2_RENDERER "Build SC2 Renderer library" ON)
 option(BUILD_API_EXAMPLES "Build Examples" ON)
 option(BUILD_API_TESTS "Build Tests" ON)
+option(BUILD_UNIT_TESTS "Build doctest-based unit tests (no game client required)" OFF)
 
 set(SC2_VERSION "5.0.14" CACHE STRING "Version of the target StarCraft II client")
 message(STATUS "Target SC2 version: ${SC2_VERSION}")
@@ -76,6 +77,10 @@ endif ()
 
 if (BUILD_API_TESTS)
     add_subdirectory(tests)
+endif ()
+
+if (BUILD_UNIT_TESTS)
+    add_subdirectory(tests/unit)
 endif ()
 
 if (WSL2_CROSS_COMPILE)

--- a/src/sc2api/sc2_client.cc
+++ b/src/sc2api/sc2_client.cc
@@ -92,6 +92,7 @@ public:
     std::vector<PowerSource> power_sources_;
     std::vector<Effect> effects_;
     std::vector<RadarRing> radar_rings_;
+    std::vector<ActionError> action_errors_;
     std::vector<UpgradeID> upgrades_;
     std::vector<UpgradeID> upgrades_previous_;
     std::vector<ChatMessage> chat_;
@@ -168,6 +169,9 @@ public:
     }
     const std::vector<RadarRing>& GetRadarRings() const final {
         return radar_rings_;
+    }
+    const std::vector<ActionError>& GetActionErrors() const final {
+        return action_errors_;
     }
     const std::vector<UpgradeID>& GetUpgrades() const final {
         return upgrades_;
@@ -619,6 +623,17 @@ bool ObservationImp::UpdateObservation() {
     chat_.clear();
     for (const auto& message : response_->chat()) {
         chat_.push_back({message.player_id(), message.message()});
+    }
+
+    action_errors_.clear();
+    action_errors_.reserve(response_->action_errors_size());
+    for (int i = 0; i < response_->action_errors_size(); ++i) {
+        const SC2APIProtocol::ActionError& err = response_->action_errors(i);
+        ActionError pod_err;
+        pod_err.unit_tag = err.unit_tag();
+        pod_err.ability_id = err.ability_id();
+        pod_err.result = static_cast<uint32_t>(err.result());
+        action_errors_.push_back(pod_err);
     }
 
     ObservationRawPtr observation_raw;

--- a/src/sc2api/sc2_client.cc
+++ b/src/sc2api/sc2_client.cc
@@ -2182,6 +2182,86 @@ void ControlImp::IssueAlertEvents() {
                 client_.OnNydusDetected();
                 break;
             }
+            case SC2APIProtocol::Alert::AlertError: {
+                client_.OnAlertError();
+                break;
+            }
+            case SC2APIProtocol::Alert::AddOnComplete: {
+                client_.OnAlertAddOnComplete();
+                break;
+            }
+            case SC2APIProtocol::Alert::BuildingComplete: {
+                client_.OnAlertBuildingComplete();
+                break;
+            }
+            case SC2APIProtocol::Alert::BuildingUnderAttack: {
+                client_.OnAlertBuildingUnderAttack();
+                break;
+            }
+            case SC2APIProtocol::Alert::LarvaHatched: {
+                client_.OnAlertLarvaHatched();
+                break;
+            }
+            case SC2APIProtocol::Alert::MergeComplete: {
+                client_.OnAlertMergeComplete();
+                break;
+            }
+            case SC2APIProtocol::Alert::MineralsExhausted: {
+                client_.OnAlertMineralsExhausted();
+                break;
+            }
+            case SC2APIProtocol::Alert::MorphComplete: {
+                client_.OnAlertMorphComplete();
+                break;
+            }
+            case SC2APIProtocol::Alert::MothershipComplete: {
+                client_.OnAlertMothershipComplete();
+                break;
+            }
+            case SC2APIProtocol::Alert::MULEExpired: {
+                client_.OnAlertMULEExpired();
+                break;
+            }
+            case SC2APIProtocol::Alert::NukeComplete: {
+                client_.OnAlertNukeComplete();
+                break;
+            }
+            case SC2APIProtocol::Alert::ResearchComplete: {
+                client_.OnAlertResearchComplete();
+                break;
+            }
+            case SC2APIProtocol::Alert::TrainError: {
+                client_.OnAlertTrainError();
+                break;
+            }
+            case SC2APIProtocol::Alert::TrainUnitComplete: {
+                client_.OnAlertTrainUnitComplete();
+                break;
+            }
+            case SC2APIProtocol::Alert::TrainWorkerComplete: {
+                client_.OnAlertTrainWorkerComplete();
+                break;
+            }
+            case SC2APIProtocol::Alert::TransformationComplete: {
+                client_.OnAlertTransformationComplete();
+                break;
+            }
+            case SC2APIProtocol::Alert::UnitUnderAttack: {
+                client_.OnAlertUnitUnderAttack();
+                break;
+            }
+            case SC2APIProtocol::Alert::UpgradeComplete: {
+                client_.OnAlertUpgradeComplete();
+                break;
+            }
+            case SC2APIProtocol::Alert::VespeneExhausted: {
+                client_.OnAlertVespeneExhausted();
+                break;
+            }
+            case SC2APIProtocol::Alert::WarpInComplete: {
+                client_.OnAlertWarpInComplete();
+                break;
+            }
             default: {
                 break;
             }

--- a/src/sc2api/sc2_client.cc
+++ b/src/sc2api/sc2_client.cc
@@ -91,6 +91,7 @@ public:
     SpatialActions rendered_actions_;
     std::vector<PowerSource> power_sources_;
     std::vector<Effect> effects_;
+    std::vector<RadarRing> radar_rings_;
     std::vector<UpgradeID> upgrades_;
     std::vector<UpgradeID> upgrades_previous_;
     std::vector<ChatMessage> chat_;
@@ -164,6 +165,9 @@ public:
     }
     const std::vector<Effect>& GetEffects() const final {
         return effects_;
+    }
+    const std::vector<RadarRing>& GetRadarRings() const final {
+        return radar_rings_;
     }
     const std::vector<UpgradeID>& GetUpgrades() const final {
         return upgrades_;
@@ -639,6 +643,13 @@ bool ObservationImp::UpdateObservation() {
     effects_.resize(observation_raw->effects_size());
     for (int i = 0; i < observation_raw->effects_size(); ++i) {
         effects_[i].ReadFromProto(observation_raw->effects(i));
+    }
+
+    radar_rings_.clear();
+    radar_rings_.reserve(observation_raw->radar_size());
+    for (int i = 0; i < observation_raw->radar_size(); ++i) {
+        const SC2APIProtocol::RadarRing& ring = observation_raw->radar(i);
+        radar_rings_.emplace_back(Point2D(ring.pos().x(), ring.pos().y()), ring.radius());
     }
 
     if (!observation_raw->has_player()) {

--- a/src/sc2api/sc2_client.h
+++ b/src/sc2api/sc2_client.h
@@ -120,44 +120,64 @@ public:
 
     //! \name Extended alert hooks. All default to noop, override only what you use.
     //!@{
+    //! Called when a generic in-game error alert is raised.
     virtual void OnAlertError() {
     }
+    //! Called when an add-on (Reactor / Tech Lab) finishes construction.
     virtual void OnAlertAddOnComplete() {
     }
+    //! Called when a building finishes construction.
     virtual void OnAlertBuildingComplete() {
     }
+    //! Called when one of the player's buildings is under attack.
     virtual void OnAlertBuildingUnderAttack() {
     }
+    //! Called when a larva hatches.
     virtual void OnAlertLarvaHatched() {
     }
+    //! Called when an Archon merge completes.
     virtual void OnAlertMergeComplete() {
     }
+    //! Called when a mineral patch is exhausted.
     virtual void OnAlertMineralsExhausted() {
     }
+    //! Called when a unit morph completes.
     virtual void OnAlertMorphComplete() {
     }
+    //! Called when a Mothership finishes construction.
     virtual void OnAlertMothershipComplete() {
     }
+    //! Called when a MULE expires.
     virtual void OnAlertMULEExpired() {
     }
+    //! Called when a Nuke launch completes.
     virtual void OnAlertNukeComplete() {
     }
+    //! Called when a research alert is raised.
     virtual void OnAlertResearchComplete() {
     }
+    //! Called when a training order fails.
     virtual void OnAlertTrainError() {
     }
+    //! Called when a unit finishes training.
     virtual void OnAlertTrainUnitComplete() {
     }
+    //! Called when a worker finishes training.
     virtual void OnAlertTrainWorkerComplete() {
     }
+    //! Called when a unit transformation completes.
     virtual void OnAlertTransformationComplete() {
     }
+    //! Called when one of the player's units is under attack.
     virtual void OnAlertUnitUnderAttack() {
     }
+    //! Called when an upgrade completes.
     virtual void OnAlertUpgradeComplete() {
     }
+    //! Called when a vespene geyser is exhausted.
     virtual void OnAlertVespeneExhausted() {
     }
+    //! Called when a Protoss warp-in completes.
     virtual void OnAlertWarpInComplete() {
     }
     //!@}

--- a/src/sc2api/sc2_client.h
+++ b/src/sc2api/sc2_client.h
@@ -118,6 +118,50 @@ public:
     virtual void OnNuclearLaunchDetected() {
     }
 
+    //! \name Extended alert hooks. All default to noop, override only what you use.
+    //!@{
+    virtual void OnAlertError() {
+    }
+    virtual void OnAlertAddOnComplete() {
+    }
+    virtual void OnAlertBuildingComplete() {
+    }
+    virtual void OnAlertBuildingUnderAttack() {
+    }
+    virtual void OnAlertLarvaHatched() {
+    }
+    virtual void OnAlertMergeComplete() {
+    }
+    virtual void OnAlertMineralsExhausted() {
+    }
+    virtual void OnAlertMorphComplete() {
+    }
+    virtual void OnAlertMothershipComplete() {
+    }
+    virtual void OnAlertMULEExpired() {
+    }
+    virtual void OnAlertNukeComplete() {
+    }
+    virtual void OnAlertResearchComplete() {
+    }
+    virtual void OnAlertTrainError() {
+    }
+    virtual void OnAlertTrainUnitComplete() {
+    }
+    virtual void OnAlertTrainWorkerComplete() {
+    }
+    virtual void OnAlertTransformationComplete() {
+    }
+    virtual void OnAlertUnitUnderAttack() {
+    }
+    virtual void OnAlertUpgradeComplete() {
+    }
+    virtual void OnAlertVespeneExhausted() {
+    }
+    virtual void OnAlertWarpInComplete() {
+    }
+    //!@}
+
     //! Called when an enemy unit enters vision from out of fog of war.
     //!< \param unit The unit entering vision.
     virtual void OnUnitEnterVision(const Unit*) {

--- a/src/sc2api/sc2_connection.cc
+++ b/src/sc2api/sc2_connection.cc
@@ -153,7 +153,14 @@ bool Connection::Receive(SC2APIProtocol::Response*& response, unsigned int timeo
     lock.unlock();
     response = nullptr;
     Disconnect();
-    queue_.clear();
+
+    {
+        std::lock_guard<std::mutex> guard(mutex_);
+        for (auto* r : queue_) {
+            delete r;
+        }
+        queue_.clear();
+    }
 
     // Execute the timeout callback if it exists.
     if (timeout_callback_) {

--- a/src/sc2api/sc2_coordinator.cc
+++ b/src/sc2api/sc2_coordinator.cc
@@ -566,7 +566,7 @@ bool CoordinatorImp::JoinGame() {
 
         if (!game_join_request) {
             std::cerr << "Unable to join game." << std::endl;
-            exit(1);
+            throw ClientConnectionError("Unable to join game (RequestJoinGame failed).");
         }
     }
 
@@ -614,7 +614,7 @@ bool CoordinatorImp::StartGame() {
     bool is_game_created = CreateGame();
     if (!is_game_created) {
         std::cerr << "Failed to create game." << std::endl;
-        exit(1);
+        throw ClientConnectionError("Failed to create game (CreateGame returned false).");
     }
     return JoinGame();
 }
@@ -708,8 +708,7 @@ void Coordinator::LaunchStarcraft() {
             std::cerr << imp_->process_settings_.process_path << " does not exist on your filesystem.";
         }
         std::cerr << std::endl;
-        assert(!"Could not find the executable. Supply a valid path.");
-        exit(1);
+        throw ClientConnectionError("StarCraft II executable not found at: " + imp_->process_settings_.process_path);
     }
 
     assert(!imp_->agents_.empty());
@@ -733,7 +732,7 @@ void Coordinator::Connect(int port) {
     if (!imp_->agents_.front()->Control()->Connect(imp_->process_settings_.net_address, port,
                                                    imp_->process_settings_.timeout_ms)) {
         std::cerr << "Failed to attach to starcraft." << std::endl;
-        exit(1);
+        throw ClientConnectionError(imp_->process_settings_.net_address, port);
     }
 
     // Assume starcraft has started after succesfully attaching to a server.

--- a/src/sc2api/sc2_data.cc
+++ b/src/sc2api/sc2_data.cc
@@ -385,6 +385,12 @@ void Effect::ReadFromProto(const SC2APIProtocol::Effect& effect) {
         const SC2APIProtocol::Point2D& pos = effect.pos(i);
         positions.push_back(Point2D(pos.x(), pos.y()));
     }
+    if (effect.has_alliance())
+        alliance = static_cast<int32_t>(effect.alliance());
+    if (effect.has_owner())
+        owner = effect.owner();
+    if (effect.has_radius())
+        radius = effect.radius();
 }
 
 AbilityID GetGeneralizedAbilityID(uint32_t ability_id, const ObservationInterface& observation) {

--- a/src/sc2api/sc2_data.h
+++ b/src/sc2api/sc2_data.h
@@ -273,6 +273,16 @@ struct RadarRing {
     float radius = 0.0f;
 };
 
+//! An action error raised by the SC2 server when a command is rejected.
+struct ActionError {
+    //! Tag of the unit the action was directed at. 0 if not applicable.
+    uint64_t unit_tag = 0;
+    //! AbilityID of the rejected action.
+    uint32_t ability_id = 0;
+    //! Result code (SC2APIProtocol::ActionResult value).
+    uint32_t result = 0;
+};
+
 //! Power source information for Protoss.
 struct PowerSource {
     PowerSource(const Point2D in_position, float in_radius, Tag in_tag)

--- a/src/sc2api/sc2_data.h
+++ b/src/sc2api/sc2_data.h
@@ -261,6 +261,18 @@ struct EffectData {
 
 typedef std::vector<EffectData> Effects;
 
+//! Radar ring visible from a sensor unit (Sensor Tower, Raven, etc.).
+struct RadarRing {
+    RadarRing() = default;
+    RadarRing(const Point2D in_position, float in_radius) : position(in_position), radius(in_radius) {
+    }
+
+    //! Center position of the radar ring.
+    Point2D position;
+    //! Detection radius.
+    float radius = 0.0f;
+};
+
 //! Power source information for Protoss.
 struct PowerSource {
     PowerSource(const Point2D in_position, float in_radius, Tag in_tag)

--- a/src/sc2api/sc2_data.h
+++ b/src/sc2api/sc2_data.h
@@ -281,6 +281,12 @@ struct Effect {
     //! All the positions that this effect is impacting on the map.
     //! eg. The Lurker's attack impacts multiple positions in a line.
     std::vector<Point2D> positions;
+    //! Alliance of the unit that cast the effect (SC2APIProtocol::Alliance values).
+    int32_t alliance = 3;
+    //! Player id of the caster.
+    int32_t owner = 0;
+    //! Impact radius of the effect.
+    float radius = 0.0f;
 
     void ReadFromProto(const SC2APIProtocol::Effect& effect);
 };

--- a/src/sc2api/sc2_errors.h
+++ b/src/sc2api/sc2_errors.h
@@ -9,6 +9,9 @@ struct ClientConnectionError : std::runtime_error {
     ClientConnectionError(const std::string& net_address_, int port_)
         : std::runtime_error("Failed connect to client " + net_address_ + ":" + std::to_string(port_)) {
     }
+    //! Generic constructor for non-network connection errors.
+    explicit ClientConnectionError(const std::string& message) : std::runtime_error(message) {
+    }
 };
 
 }  // namespace sc2

--- a/src/sc2api/sc2_errors.h
+++ b/src/sc2api/sc2_errors.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <exception>
+#include <stdexcept>
 #include <string>
 
 namespace sc2 {

--- a/src/sc2api/sc2_interfaces.h
+++ b/src/sc2api/sc2_interfaces.h
@@ -100,6 +100,10 @@ public:
     //!< \return List of effects.
     virtual const std::vector<Effect>& GetEffects() const = 0;
 
+    //! Gets all radar rings (Sensor Tower / Raven detection zones) in vision of the current player.
+    //!< \return List of radar rings.
+    virtual const std::vector<RadarRing>& GetRadarRings() const = 0;
+
     //! Gets all upgrades.
     //!< \return List of upgrades.
     virtual const std::vector<UpgradeID>& GetUpgrades() const = 0;

--- a/src/sc2api/sc2_interfaces.h
+++ b/src/sc2api/sc2_interfaces.h
@@ -104,6 +104,11 @@ public:
     //!< \return List of radar rings.
     virtual const std::vector<RadarRing>& GetRadarRings() const = 0;
 
+    //! Gets action errors raised by SC2 since last observation.
+    //!< Useful for instant feedback to action pipelines on rejected commands.
+    //!< \return List of action errors.
+    virtual const std::vector<ActionError>& GetActionErrors() const = 0;
+
     //! Gets all upgrades.
     //!< \return List of upgrades.
     virtual const std::vector<UpgradeID>& GetUpgrades() const = 0;

--- a/src/sc2api/sc2_proto_to_pods.cc
+++ b/src/sc2api/sc2_proto_to_pods.cc
@@ -318,6 +318,25 @@ bool Convert(const ObservationRawPtr& observation_raw, UnitPool& unit_pool, uint
         }
 
         unit->is_powered = observation_unit.is_powered();
+        unit->is_active = observation_unit.is_active();
+        unit->buff_duration_remain = observation_unit.buff_duration_remain();
+        unit->buff_duration_max = observation_unit.buff_duration_max();
+
+        unit->rally_targets.clear();
+        unit->rally_targets.reserve(observation_unit.rally_targets_size());
+        for (int i = 0; i < observation_unit.rally_targets_size(); ++i) {
+            const auto& rt_proto = observation_unit.rally_targets(i);
+            RallyTarget rt;
+            if (rt_proto.has_point()) {
+                rt.point.x = rt_proto.point().x();
+                rt.point.y = rt_proto.point().y();
+                rt.point.z = rt_proto.point().z();
+            }
+            if (rt_proto.has_tag())
+                rt.tag = rt_proto.tag();
+            unit->rally_targets.push_back(rt);
+        }
+
         unit->is_alive = true;
         if (unit->last_seen_game_loop < prev_game_loop)
             unit_pool.AddUnitEnteredVision(unit);

--- a/src/sc2api/sc2_proto_to_pods.cc
+++ b/src/sc2api/sc2_proto_to_pods.cc
@@ -275,6 +275,7 @@ bool Convert(const ObservationRawPtr& observation_raw, UnitPool& unit_pool, uint
             order.target_unit_tag = order_proto.target_unit_tag();
             order.target_pos.x = order_proto.target_world_space_pos().x();
             order.target_pos.y = order_proto.target_world_space_pos().y();
+            order.target_pos.z = order_proto.target_world_space_pos().z();
             order.progress = order_proto.progress();
             unit->orders.push_back(order);
         }

--- a/src/sc2api/sc2_proto_to_pods.cc
+++ b/src/sc2api/sc2_proto_to_pods.cc
@@ -197,10 +197,15 @@ bool Convert(const ObservationRawPtr& observation_raw, UnitPool& unit_pool, uint
         }
 
         if (!Convert(observation_unit.display_type(), unit->display_type)) {
-            return false;
+            std::cerr << "[cpp-sc2 warn] unit tag=" << observation_unit.tag()
+                      << " has unknown display_type=" << static_cast<int>(observation_unit.display_type())
+                      << ", skipping\n";
+            continue;
         }
         if (!Convert(observation_unit.alliance(), unit->alliance)) {
-            return false;
+            std::cerr << "[cpp-sc2 warn] unit tag=" << observation_unit.tag()
+                      << " has unknown alliance=" << static_cast<int>(observation_unit.alliance()) << ", skipping\n";
+            continue;
         }
 
         unit->tag = observation_unit.tag();

--- a/src/sc2api/sc2_unit.h
+++ b/src/sc2api/sc2_unit.h
@@ -26,7 +26,7 @@ struct UnitOrder {
     //! Target unit of the order, if there is one.
     Tag target_unit_tag = NullTag;
     //! Target position of the order, if there is one.
-    Point2D target_pos;
+    Point3D target_pos;
     //! Progress of the order.
     float progress = 0.0F;
 };

--- a/src/sc2api/sc2_unit.h
+++ b/src/sc2api/sc2_unit.h
@@ -31,6 +31,14 @@ struct UnitOrder {
     float progress = 0.0F;
 };
 
+//! A rally target on a producer building.
+struct RallyTarget {
+    //! Position of the rally point.
+    Point3D point;
+    //! Tag of the unit being rallied to. NullTag if rally on a position.
+    Tag tag = NullTag;
+};
+
 //! A passenger on a transport.
 struct PassengerUnit {
     //! The tag of the unit in the transport.
@@ -179,6 +187,17 @@ public:
     std::vector<BuffID> buffs;
     //! Whether the unit is powered by a pylon.
     bool is_powered;
+
+    //! Whether a producer building is actively producing or researching. Only valid for this player's units.
+    bool is_active = false;
+
+    //! Rally targets on a producer building. Only valid for this player's units.
+    std::vector<RallyTarget> rally_targets;
+
+    //! Buff or temporary-unit duration remaining. Only valid for this player's units.
+    int32_t buff_duration_remain = 0;
+    //! Buff or temporary-unit total duration. Only valid for this player's units.
+    int32_t buff_duration_max = 0;
 
     //! Whether the unit is alive or not.
     bool is_alive;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,0 +1,28 @@
+message(STATUS "FetchContent: doctest")
+
+FetchContent_Declare(
+    doctest
+    GIT_REPOSITORY https://github.com/doctest/doctest.git
+    GIT_TAG v2.4.11
+    GIT_PROGRESS TRUE
+)
+FetchContent_MakeAvailable(doctest)
+
+add_executable(cpp_sc2_unit_tests
+    test_main.cc
+    test_ability_data.cc
+    test_score_details.cc
+)
+
+target_include_directories(cpp_sc2_unit_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(cpp_sc2_unit_tests PRIVATE
+    sc2api
+    sc2lib
+    doctest::doctest
+)
+
+set_target_properties(cpp_sc2_unit_tests PROPERTIES FOLDER tests)

--- a/tests/unit/test_ability_data.cc
+++ b/tests/unit/test_ability_data.cc
@@ -1,0 +1,36 @@
+#include <doctest/doctest.h>
+
+#include "s2clientprotocol/sc2api.pb.h"
+#include "sc2api/sc2_data.h"
+
+TEST_CASE("AbilityData.is_instant_placement reads the value, not has_X") {
+    SC2APIProtocol::AbilityData proto;
+    proto.set_ability_id(123);
+    proto.set_is_instant_placement(true);
+
+    sc2::AbilityData pod;
+    pod.ReadFromProto(proto);
+
+    CHECK(pod.is_instant_placement == true);
+}
+
+TEST_CASE("AbilityData.is_instant_placement is false when set to false") {
+    SC2APIProtocol::AbilityData proto;
+    proto.set_ability_id(124);
+    proto.set_is_instant_placement(false);
+
+    sc2::AbilityData pod;
+    pod.ReadFromProto(proto);
+
+    CHECK(pod.is_instant_placement == false);
+}
+
+TEST_CASE("AbilityData.is_instant_placement defaults to false when absent") {
+    SC2APIProtocol::AbilityData proto;
+    proto.set_ability_id(125);
+
+    sc2::AbilityData pod;
+    pod.ReadFromProto(proto);
+
+    CHECK(pod.is_instant_placement == false);
+}

--- a/tests/unit/test_main.cc
+++ b/tests/unit/test_main.cc
@@ -1,0 +1,2 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>

--- a/tests/unit/test_score_details.cc
+++ b/tests/unit/test_score_details.cc
@@ -1,0 +1,30 @@
+#include <doctest/doctest.h>
+
+#include "s2clientprotocol/sc2api.pb.h"
+#include "sc2api/sc2_score.h"
+
+namespace sc2 {
+bool Convert(const SC2APIProtocol::VitalScoreDetails& details_proto, VitalScoreDetails& vital_score_details);
+}  // namespace sc2
+
+TEST_CASE("Convert(VitalScoreDetails) populates life/shields/energy") {
+    SC2APIProtocol::VitalScoreDetails proto;
+    proto.set_life(100.5f);
+    proto.set_shields(50.25f);
+    proto.set_energy(25.0f);
+
+    sc2::VitalScoreDetails pod;
+    REQUIRE(sc2::Convert(proto, pod));
+
+    CHECK(pod.life == doctest::Approx(100.5f));
+    CHECK(pod.shields == doctest::Approx(50.25f));
+    CHECK(pod.energy == doctest::Approx(25.0f));
+}
+
+TEST_CASE("ScoreDetails.collected_vespene is a writable member with default 0") {
+    sc2::ScoreDetails sd;
+    CHECK(sd.collected_vespene == doctest::Approx(0.0f));
+
+    sd.collected_vespene = 12345.0f;
+    CHECK(sd.collected_vespene == doctest::Approx(12345.0f));
+}


### PR DESCRIPTION
10 patches accumulated,
three bugs and seven additions.

- Connection.Receive could leak a Response and race the queue when a timeout fired
- The converter would abort the entire tick if SC2 returned an out-of-range enum (happens with mods or custom maps)
- Coordinator used to call exit(1) when SC2 failed to start, killing the process before the client could clean up. Now throws ClientConnectionError instead
- UnitOrder.target_pos was truncated to 2D, terrain altitude lost. Now Point3D (still backward-compatible since Point3D exposes .x and .y)
- Effect.alliance / owner / radius: useful for Scanner Sweep (knowing if it's the opponent scanning you), Blinding Cloud or Corrosive Bile in team games (don't blanket your allies), and identifying which opponent landed an EMP in 2v2 / 3v3 via owner
- 4 Unit fields never extracted: is_active, buff_duration_remain / max, rally_targets
- RadarRings: your own Sensor Towers and Ravens in detect mode, never read before
- action_errors: the red "Not enough minerals" / target invalid / etc. errors from the UI are now exposed, so client code can react the same frame instead of waiting for a timeout
- 20 alerts that were silently dropped now route to dedicated OnAlert\* hooks. Before, only NuclearLaunchDetected and NydusWormDetected made it through. The other 20 (BuildingUnderAttack, MULEExpired, TrainError, etc.) were ignored
- Doctest-based unit test framework, with two regression tests on already-merged fixes (collected_vespene, is_instant_placement). Lets you write tests without launching the SC2 client

Closes #62, #71, #149.