### PR TITLE
build: Allow Cross-Compiling Proto files

### DIFF
--- a/src/sc2protocol/CMakeLists.txt
+++ b/src/sc2protocol/CMakeLists.txt
@@ -44,6 +44,19 @@ if (WSL2_CROSS_COMPILE)
     endforeach ()
 # Compile protos with protoc
 else ()
+    if (NOT Protobuf_PROTOC_EXECUTABLE)
+        message(STATUS "Searching for Protoc compiler (protoc)")
+        find_program(Protobuf_PROTOC_EXECUTABLE
+                NAMES protoc
+                PATHS /usr/bin /usr/local/bin ${PROJECT_BINARY_DIR}/bin
+                NO_CMAKE_FIND_ROOT_PATH
+        )
+    endif()
+
+    if (NOT Protobuf_PROTOC_EXECUTABLE)
+        message(FATAL_ERROR "Protobuf compiler (protoc) not specified and not found on host!")
+    endif()
+
     foreach (proto ${proto_files})
         get_filename_component(proto_name_we ${proto} NAME_WE)
         set(protoc_out_cc "${proto_generation_dir}/${proto_name_we}.pb.cc")
@@ -54,11 +67,11 @@ else ()
                 "${protoc_out_cc}"
                 "${protoc_out_h}"
             COMMAND
-                "${PROJECT_BINARY_DIR}/bin/protoc"
+                "${Protobuf_PROTOC_EXECUTABLE}"
                 "-I=${sc2protocol_SOURCE_DIR}"
                 "--cpp_out=${PROJECT_BINARY_DIR}/generated"
                 "${proto}"
-            DEPENDS protoc
+            DEPENDS ${Protobuf_PROTOC_EXECUTABLE} ${proto_files}
             VERBATIM
         )
     endforeach()

--- a/thirdparty/cmake/protobuf.cmake
+++ b/thirdparty/cmake/protobuf.cmake
@@ -4,7 +4,7 @@ set(protobuf_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(protobuf_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 
 # Do not build Protobuf compiler if using precompiled proto files
-if (WSL2_CROSS_COMPILE)
+if (WSL2_CROSS_COMPILE OR Protobuf_PROTOC_EXECUTABLE)
     set(protobuf_BUILD_PROTOC_BINARIES OFF CACHE BOOL "" FORCE)
 endif ()
 


### PR DESCRIPTION
Adds in respect for the setting Protobuf_PROTOC_EXECUTABLE. If provided the Protoc executable will not be built and we will use the provided file to build the proto files. Do note that it must be the same version as the library so currently that would be v33.x

No changes where made to WSL2_CROSS_COMPILE so if set the library will still use precompiled protos