### PR TITLE
feat: remote Connect host, civetweb client-only init, host protoc when cross-compiling

### DIFF
--- a/src/sc2api/sc2_connection.cc
+++ b/src/sc2api/sc2_connection.cc
@@ -15,23 +15,14 @@ bool StartCivetweb() {
         return true;
     }
 
-    const char* options[] = {
-        "request_timeout_ms", "5000", "websocket_timeout_ms", "1200000", "num_threads", "4", "tcp_nodelay", "1", 0};
-
-    struct mg_callbacks callbacks = {0};
-
-    struct mg_init_data mg_start_init_data = {0};
-    mg_start_init_data.callbacks = &callbacks;
-    mg_start_init_data.configuration_options = options;
-
-    struct mg_error_data mg_start_error_data = {0};
-    char ebuff[256] = {0};
-    mg_start_error_data.text = ebuff;
-    mg_start_error_data.text_buffer_size = sizeof(ebuff);
-
-    const auto* ctx = mg_start2(&mg_start_init_data, &mg_start_error_data);
-    if (!ctx) {
-        std::cerr << "Failed to start civetweb server: " << ebuff << std::endl;
+    // cpp-sc2 is a websocket client. mg_start2() starts an HTTP server that
+    // binds 8080 by default, so the process appears to listen on 8080 even
+    // though the SC2 connection uses an ephemeral source port. AI Arena's
+    // get_ipv4_port_for_pid then maps the bot to the listen port and never
+    // forwards the real websocket. mg_init_library only enables the client.
+    const unsigned got = mg_init_library(MG_FEATURES_WEBSOCKET);
+    if ((got & MG_FEATURES_WEBSOCKET) == 0) {
+        std::cerr << "Failed to init civetweb websocket client" << std::endl;
         return false;
     }
 

--- a/src/sc2api/sc2_coordinator.cc
+++ b/src/sc2api/sc2_coordinator.cc
@@ -876,6 +876,10 @@ void Coordinator::SetPortStart(int port_start) {
     imp_->process_settings_.port_start = port_start;
 }
 
+void Coordinator::SetNetAddress(const std::string& net_address) {
+    imp_->process_settings_.net_address = net_address;
+}
+
 void Coordinator::SetFeatureLayers(const FeatureLayerSettings& settings) {
     // Feature Layers must be set before LaunchStarcraft is called.
     assert(!imp_->starcraft_started_);

--- a/src/sc2api/sc2_coordinator.h
+++ b/src/sc2api/sc2_coordinator.h
@@ -70,8 +70,10 @@ public:
     //! \param port_start First port number.
     void SetPortStart(int port_start);
 
-    //! Sets the address used by Connect(int). Required for AI Arena `--LadderServer`.
-    //! \param net_address Host to attach to (for example a compose service IP).
+    //! Sets the host used by Connect(int). Default is 127.0.0.1.
+    //! Needed when attaching to a remote SC2 websocket (AI Arena `--LadderServer`).
+    //! \param net_address Hostname or IP to attach to.
+    //! \sa Connect
     void SetNetAddress(const std::string& net_address);
 
     //! Indicates whether feature layers should be provided in the observation.
@@ -132,7 +134,10 @@ public:
     //! Uses settings gathered from LoadSettings, specifically the path to the executable, to run StarCraft II.
     void LaunchStarcraft();
 
-    //! Attaches to a running Starcraft.
+    //! Attaches to a running StarCraft II websocket.
+    //! Uses the host from SetNetAddress (default 127.0.0.1).
+    //! \param port Game port (AI Arena `--GamePort`).
+    //! \sa SetNetAddress
     void Connect(int port);
 
     //! Starts a game on a certain map. There are multiple ways to specify a map:

--- a/src/sc2api/sc2_coordinator.h
+++ b/src/sc2api/sc2_coordinator.h
@@ -70,6 +70,10 @@ public:
     //! \param port_start First port number.
     void SetPortStart(int port_start);
 
+    //! Sets the address used by Connect(int). Required for AI Arena `--LadderServer`.
+    //! \param net_address Host to attach to (for example a compose service IP).
+    void SetNetAddress(const std::string& net_address);
+
     //! Indicates whether feature layers should be provided in the observation.
     //! \param settings Configuration of feature layer settings.
     //! \sa FeatureLayerSettings

--- a/src/sc2protocol/CMakeLists.txt
+++ b/src/sc2protocol/CMakeLists.txt
@@ -44,6 +44,26 @@ if (WSL2_CROSS_COMPILE)
     endforeach ()
 # Compile protos with protoc
 else ()
+    if (Protobuf_PROTOC_EXECUTABLE)
+        set(protoc_executable ${Protobuf_PROTOC_EXECUTABLE})
+        set(protoc_depends ${Protobuf_PROTOC_EXECUTABLE})
+    elseif (CMAKE_CROSSCOMPILING)
+        find_program(protoc_executable
+            NAMES protoc
+            PATHS /usr/bin /usr/local/bin
+            NO_CMAKE_FIND_ROOT_PATH
+        )
+        if (NOT protoc_executable)
+            message(FATAL_ERROR
+                "Cross-compiling needs a host protoc. "
+                "Pass -DProtobuf_PROTOC_EXECUTABLE=<path>.")
+        endif()
+        set(protoc_depends ${protoc_executable})
+    else ()
+        set(protoc_executable ${PROJECT_BINARY_DIR}/bin/protoc)
+        set(protoc_depends protoc)
+    endif()
+
     foreach (proto ${proto_files})
         get_filename_component(proto_name_we ${proto} NAME_WE)
         set(protoc_out_cc "${proto_generation_dir}/${proto_name_we}.pb.cc")
@@ -54,11 +74,11 @@ else ()
                 "${protoc_out_cc}"
                 "${protoc_out_h}"
             COMMAND
-                "${PROJECT_BINARY_DIR}/bin/protoc"
+                "${protoc_executable}"
                 "-I=${sc2protocol_SOURCE_DIR}"
                 "--cpp_out=${PROJECT_BINARY_DIR}/generated"
                 "${proto}"
-            DEPENDS protoc
+            DEPENDS ${protoc_depends} ${proto_files}
             VERBATIM
         )
     endforeach()

--- a/src/sc2protocol/CMakeLists.txt
+++ b/src/sc2protocol/CMakeLists.txt
@@ -78,7 +78,7 @@ else ()
                 "-I=${sc2protocol_SOURCE_DIR}"
                 "--cpp_out=${PROJECT_BINARY_DIR}/generated"
                 "${proto}"
-            DEPENDS ${protoc_depends} ${proto_files}
+            DEPENDS ${protoc_depends} ${proto}
             VERBATIM
         )
     endforeach()

--- a/thirdparty/cmake/protobuf.cmake
+++ b/thirdparty/cmake/protobuf.cmake
@@ -3,8 +3,9 @@ message(STATUS "FetchContent: protobuf")
 set(protobuf_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(protobuf_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 
-# Do not build Protobuf compiler if using precompiled proto files
-if (WSL2_CROSS_COMPILE)
+# Do not build a target protoc when it cannot run (WSL2 precompiled protos,
+# CMAKE_CROSSCOMPILING) or when the host already supplied one.
+if (WSL2_CROSS_COMPILE OR CMAKE_CROSSCOMPILING OR Protobuf_PROTOC_EXECUTABLE)
     set(protobuf_BUILD_PROTOC_BINARIES OFF CACHE BOOL "" FORCE)
 endif ()
 


### PR DESCRIPTION
Three pieces. Happy to split if that is easier to review.

## Coordinator::SetNetAddress

`Connect(int)` already reads `process_settings.net_address`, but there was no public setter, so the host was stuck at `127.0.0.1`. Call this before `Connect` when the websocket is not on localhost.

```cpp
coordinator.SetNetAddress(host);
coordinator.Connect(game_port);
coordinator.SetupPorts(2, start_port, false);
coordinator.JoinGame();
```

## Civetweb client-only init

cpp-sc2 only uses mg_connect_websocket_client. StartCivetweb() called mg_start2(), which starts an HTTP server and binds 8080 by default. That listen socket is then the process's first TCP port, so anything that maps the bot by pid (AI Arena get_ipv4_port_for_pid) never sees the real websocket source port.

This switches to mg_init_library(MG_FEATURES_WEBSOCKET). After that, Player Details, JoinGame, and RequestPing succeed against aiarena/arenaclient-bot v0.8.0.

## Host protoc when cross-compiling

Supersedes the CMake from #158 (Cross).

• Honor Protobuf_PROTOC_EXECUTABLE and CMAKE_CROSSCOMPILING so MinGW/Docker can generate protos with a host protoc instead of only WSL2_CROSS_COMPILE precompiled dumps.
• If cross-compiling and no executable was passed, search the host PATH (NO_CMAKE_FIND_ROOT_PATH) and fail with a clear error.
• Native builds still build and DEPENDS the in-tree protoc target.
• WSL2_CROSS_COMPILE is unchanged.
• Host protoc must match the protobuf GIT_TAG (still v33.0).