### PR TITLE
feat: expose raw camera moves in observation actions

### DIFF
--- a/src/sc2api/sc2_action.h
+++ b/src/sc2api/sc2_action.h
@@ -19,7 +19,9 @@ struct ActionRaw {
         //! The target is a unit tag, could also be a snapshot in the fog-of-war.
         TargetUnitTag,
         //! The target is a point.
-        TargetPosition
+        TargetPosition,
+        //! Raw camera move. ability_id is unused; target_point/target_z hold world space.
+        TargetCamera
     };
 
     //! The ID of the ability to invoke.
@@ -30,8 +32,10 @@ struct ActionRaw {
     TargetType target_type = TargetNone;
     //! The target of this action. Valid only when target_type == TargetUnitTag.
     Tag target_tag = NullTag;
-    //! The target point for this action. Valid only when target_type == TargetPosition.
+    //! The target point for this action. Valid when target_type == TargetPosition or TargetCamera.
     Point2D target_point;
+    //! World-space Z for TargetCamera. Unused for other target types.
+    float target_z = 0.0f;
 
     //! Comparison overload.
 
@@ -49,6 +53,9 @@ struct ActionRaw {
             return false;
         }
         if (target_point.y != a.target_point.y) {
+            return false;
+        }
+        if (target_z != a.target_z) {
             return false;
         }
         return true;

--- a/src/sc2api/sc2_client.cc
+++ b/src/sc2api/sc2_client.cc
@@ -602,6 +602,9 @@ bool ObservationImp::UpdateObservation() {
     // Remap ability ids.
     {
         for (ActionRaw& action : raw_actions_) {
+            if (action.target_type == ActionRaw::TargetCamera) {
+                continue;
+            }
             action.ability_id = GetGeneralizedAbilityID(action.ability_id, *this);
         }
         for (SpatialUnitCommand& spatial_action : feature_layer_actions_.unit_commands) {

--- a/src/sc2api/sc2_gametypes.h
+++ b/src/sc2api/sc2_gametypes.h
@@ -123,6 +123,9 @@ static const int max_num_players = 16;
 struct ReplayPlayerInfo {
     //! Player ID.
     int player_id;
+    //! Display name from RequestReplayInfo. ResponseGameInfo during playback
+    //! often leaves PlayerInfo.player_name empty; this is the reliable source.
+    std::string name;
     //! Player ranking.
     int mmr;
     //! Player actions per minute.

--- a/src/sc2api/sc2_proto_to_pods.cc
+++ b/src/sc2api/sc2_proto_to_pods.cc
@@ -370,6 +370,18 @@ void ConvertRawActions(const ResponseObservationPtr& response_observation_ptr, R
             continue;
         }
         const SC2APIProtocol::ActionRaw& action_raw = proto_action.action_raw();
+        if (action_raw.has_camera_move()) {
+            const SC2APIProtocol::ActionRawCameraMove& camera_move = action_raw.camera_move();
+            ActionRaw action;
+            action.target_type = ActionRaw::TargetCamera;
+            if (camera_move.has_center_world_space()) {
+                action.target_point.x = camera_move.center_world_space().x();
+                action.target_point.y = camera_move.center_world_space().y();
+                action.target_z = camera_move.center_world_space().z();
+            }
+            actions.push_back(action);
+            continue;
+        }
         if (!action_raw.has_unit_command()) {
             continue;
         }

--- a/src/sc2api/sc2_replay_observer.cc
+++ b/src/sc2api/sc2_replay_observer.cc
@@ -112,6 +112,9 @@ bool ReplayControlImp::GatherReplayInfo(const std::string& path, bool download_d
         if (player_info_extra_proto.has_player_info()) {
             const SC2APIProtocol::PlayerInfo& player_info_proto = player_info_extra_proto.player_info();
             player_info.player_id = player_info_proto.player_id();
+            if (player_info_proto.has_player_name()) {
+                player_info.name = player_info_proto.player_name();
+            }
             if (player_info_proto.has_race_actual()) {
                 player_info.race = ConvertRaceFromProto(player_info_proto.race_actual());
             }

--- a/src/sc2utils/sc2_scan_directory.cc
+++ b/src/sc2utils/sc2_scan_directory.cc
@@ -13,6 +13,23 @@
 
 namespace sc2 {
 
+namespace {
+
+std::string JoinDirFile(const char* directory_path, const char* name) {
+    std::string path(directory_path);
+    if (!path.empty() && path.back() != '/' && path.back() != '\\') {
+#ifdef _WIN32
+        path += '\\';
+#else
+        path += '/';
+#endif
+    }
+    path += name;
+    return path;
+}
+
+}  // namespace
+
 int scan_directory(const char* directory_path, std::vector<std::string>& files, bool full_path, bool list_directories) {
     if (!directory_path || !*directory_path) {
         return 0;
@@ -36,8 +53,9 @@ int scan_directory(const char* directory_path, std::vector<std::string>& files, 
                 if (!full_path) {
                     files.push_back(ent->d_name);
                 } else {
-                    files.push_back(std::string(directory_path) + std::string(ent->d_name));
+                    files.push_back(JoinDirFile(directory_path, ent->d_name));
                 }
+                break;
             }
             case DT_DIR: {
                 if (!list_directories || !*ent->d_name) {
@@ -51,9 +69,10 @@ int scan_directory(const char* directory_path, std::vector<std::string>& files, 
                 if (!full_path) {
                     files.push_back(ent->d_name);
                 } else {
-                    files.push_back(std::string(directory_path) + std::string(ent->d_name));
+                    files.push_back(JoinDirFile(directory_path, ent->d_name));
                 }
-            } break;
+                break;
+            }
         }
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,3 +29,11 @@ if (BUILD_SC2_RENDERER)
 endif ()
 
 target_link_libraries(all_tests sc2api sc2lib sc2utils)
+
+# Standalone live-client test for ReplayInfo / raw camera / chat. Avoids
+# running the full all_tests suite (multiplayer, performance, restarts).
+add_executable(test_replay_observation
+    test_replay_observation.cc
+    test_replay_observation_main.cc)
+set_target_properties(test_replay_observation PROPERTIES FOLDER tests)
+target_link_libraries(test_replay_observation sc2api sc2lib sc2utils)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,8 @@ set(sc2test_sources
     test_restart.cc
     test_snapshots.cc
     test_unit_command_common.cc
-    test_unit_command.cc)
+    test_unit_command.cc
+    test_replay_observation.cc)
 
 add_executable(all_tests ${sc2test_sources})
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,11 +29,3 @@ if (BUILD_SC2_RENDERER)
 endif ()
 
 target_link_libraries(all_tests sc2api sc2lib sc2utils)
-
-# Standalone live-client test for ReplayInfo / raw camera / chat. Avoids
-# running the full all_tests suite (multiplayer, performance, restarts).
-add_executable(test_replay_observation
-    test_replay_observation.cc
-    test_replay_observation_main.cc)
-set_target_properties(test_replay_observation PROPERTIES FOLDER tests)
-target_link_libraries(test_replay_observation sc2api sc2lib sc2utils)

--- a/tests/all_tests.cc
+++ b/tests/all_tests.cc
@@ -11,6 +11,7 @@
 #include "test_observation_interface.h"
 #include "test_performance.h"
 #include "test_rendered.h"
+#include "test_replay_observation.h"
 #include "test_restart.h"
 #include "test_snapshots.h"
 #include "test_unit_command.h"
@@ -42,6 +43,7 @@ int main(int argc, char* argv[]) {
     TEST(sc2::TestUnitCommand);
     TEST(sc2::TestPerformance);
     TEST(sc2::TestObservationInterface);
+    TEST(sc2::TestReplayObservation);
     // TEST(sc2::TestObservationActions);
 
 #ifdef BUILD_SC2_RENDERER

--- a/tests/test_replay_observation.cc
+++ b/tests/test_replay_observation.cc
@@ -142,6 +142,16 @@ public:
             chat_cleared_ = true;
         }
 
+        for (const auto& action : Observation()->GetRawActions()) {
+            if (action.target_type == ActionRaw::TargetCamera) {
+                saw_camera_ = true;
+                const float dx = action.target_point.x - kCameraTarget.x;
+                const float dy = action.target_point.y - kCameraTarget.y;
+                if ((dx * dx + dy * dy) < 16.0f) {
+                    camera_near_target_ = true;
+                }
+            }
+        }
     }
 
     bool stepped() const {
@@ -153,6 +163,12 @@ public:
     bool chat_cleared() const {
         return chat_cleared_;
     }
+    bool saw_camera() const {
+        return saw_camera_;
+    }
+    bool camera_near_target() const {
+        return camera_near_target_;
+    }
 
 private:
     std::string* errors_;
@@ -161,6 +177,8 @@ private:
     bool saw_chat_ = false;
     bool saw_chat_text_ = false;
     bool chat_cleared_ = false;
+    bool saw_camera_ = false;
+    bool camera_near_target_ = false;
 };
 
 }  // namespace
@@ -224,8 +242,10 @@ bool TestReplayObservation(int argc, char** argv) {
         std::cerr << "TestReplayObservation: ReplayObserver never stepped" << std::endl;
         success = false;
     }
-    // Camera and chat assertions land in later topic PRs. This test only
-    // requires a complete ReplayInfo including both player names.
+    if (!observer.saw_camera() || !observer.camera_near_target()) {
+        std::cerr << "TestReplayObservation: raw camera move missing from replay actions" << std::endl;
+        success = false;
+    }
     (void)observer.saw_chat_text();
     (void)observer.chat_cleared();
     return success;

--- a/tests/test_replay_observation.cc
+++ b/tests/test_replay_observation.cc
@@ -1,0 +1,234 @@
+#include "test_replay_observation.h"
+
+#include <filesystem>
+#include <iostream>
+#include <string>
+
+#include "sc2api/sc2_api.h"
+#include "sc2lib/sc2_lib.h"
+#include "sc2utils/sc2_manage_process.h"
+
+namespace sc2 {
+
+namespace {
+
+const char* kPlayerAlpha = "HelixAlpha";
+const char* kPlayerBravo = "HelixBravo";
+const char* kChatLine = "cpp-sc2 replay chat probe";
+const Point2D kCameraTarget(24.0f, 28.0f);
+
+void Report(std::string* errors, const std::string& message) {
+    std::cerr << "TestReplayObservation: " << message << std::endl;
+    if (errors->empty()) {
+        *errors = message;
+    } else {
+        *errors += "; " + message;
+    }
+}
+
+bool HasPlayerNamed(const ReplayInfo& info, const std::string& name, Race expected_race) {
+    for (int i = 0; i < info.num_players; ++i) {
+        const ReplayPlayerInfo& player = info.players[i];
+        if (player.name == name) {
+            return player.race == expected_race || player.race_selected == expected_race;
+        }
+    }
+    return false;
+}
+
+bool AssertReplayInfoComplete(const ReplayInfo& info, const std::string& replay_path, std::string* errors) {
+    bool ok = true;
+    if (info.num_players != 2) {
+        Report(errors, "expected 2 players, got " + std::to_string(info.num_players));
+        ok = false;
+    }
+    if (info.map_name.empty()) {
+        Report(errors, "map_name is empty");
+        ok = false;
+    }
+    if (info.replay_path.empty()) {
+        Report(errors, "replay_path is empty");
+        ok = false;
+    }
+    if (info.version.empty()) {
+        Report(errors, "version is empty");
+        ok = false;
+    }
+    if (info.data_version.empty()) {
+        Report(errors, "data_version is empty");
+        ok = false;
+    }
+    if (info.duration <= 0.0f) {
+        Report(errors, "duration is not positive");
+        ok = false;
+    }
+    if (info.duration_gameloops == 0) {
+        Report(errors, "duration_gameloops is 0");
+        ok = false;
+    }
+    if (info.data_build == 0) {
+        Report(errors, "data_build is 0");
+        ok = false;
+    }
+    if (info.base_build == 0) {
+        Report(errors, "base_build is 0");
+        ok = false;
+    }
+    if (!HasPlayerNamed(info, kPlayerAlpha, Race::Terran)) {
+        Report(errors, std::string("missing named Terran player ") + kPlayerAlpha);
+        ok = false;
+    }
+    if (!HasPlayerNamed(info, kPlayerBravo, Race::Zerg)) {
+        Report(errors, std::string("missing named Zerg player ") + kPlayerBravo);
+        ok = false;
+    }
+    (void)replay_path;
+    return ok;
+}
+
+class ReplayCaptureBot : public Agent {
+public:
+    explicit ReplayCaptureBot(std::string path) : replay_path_(std::move(path)) {
+    }
+
+    bool saved() const {
+        return saved_;
+    }
+
+    void OnStep() override {
+        const uint32_t loop = Observation()->GetGameLoop();
+        if (loop == 2) {
+            Actions()->SendChat(kChatLine, ChatChannel::All);
+            Debug()->DebugMoveCamera(kCameraTarget);
+            Debug()->SendDebug();
+        }
+        if (loop >= 16 && !saved_) {
+            saved_ = Control()->SaveReplay(replay_path_);
+            Debug()->DebugEndGame(true);
+            Debug()->SendDebug();
+        }
+    }
+
+private:
+    std::string replay_path_;
+    bool saved_ = false;
+};
+
+class ReplayInfoObserver : public ReplayObserver {
+public:
+    explicit ReplayInfoObserver(std::string* errors) : errors_(errors) {
+    }
+
+    bool info_ok() const {
+        return info_ok_;
+    }
+
+    bool IgnoreReplay(const ReplayInfo& replay_info, uint32_t) override {
+        info_ok_ = AssertReplayInfoComplete(replay_info, replay_info.replay_path, errors_);
+        return false;
+    }
+
+    void OnStep() override {
+        stepped_ = true;
+        const auto& chat = Observation()->GetChatMessages();
+        if (!chat.empty()) {
+            saw_chat_ = true;
+            for (const auto& message : chat) {
+                if (message.message == kChatLine) {
+                    saw_chat_text_ = true;
+                }
+            }
+        } else if (saw_chat_text_) {
+            chat_cleared_ = true;
+        }
+
+    }
+
+    bool stepped() const {
+        return stepped_;
+    }
+    bool saw_chat_text() const {
+        return saw_chat_text_;
+    }
+    bool chat_cleared() const {
+        return chat_cleared_;
+    }
+
+private:
+    std::string* errors_;
+    bool info_ok_ = false;
+    bool stepped_ = false;
+    bool saw_chat_ = false;
+    bool saw_chat_text_ = false;
+    bool chat_cleared_ = false;
+};
+
+}  // namespace
+
+bool TestReplayObservation(int argc, char** argv) {
+    const std::filesystem::path replay_dir = std::filesystem::temp_directory_path() / "cpp-sc2-replay-obs";
+    std::error_code ec;
+    std::filesystem::create_directories(replay_dir, ec);
+    const std::string replay_path = (replay_dir / "fixture.SC2Replay").string();
+    std::filesystem::remove(replay_path, ec);
+
+    {
+        Coordinator coordinator;
+        if (!coordinator.LoadSettings(argc, argv)) {
+            std::cerr << "TestReplayObservation: LoadSettings failed" << std::endl;
+            return false;
+        }
+
+        ReplayCaptureBot bot(replay_path);
+        coordinator.SetParticipants({
+            CreateParticipant(Race::Terran, &bot, kPlayerAlpha),
+            CreateComputer(Race::Zerg, Difficulty::Easy, AIBuild::RandomBuild, kPlayerBravo),
+        });
+        coordinator.LaunchStarcraft();
+        if (!coordinator.StartGame(kMapBelShirVestigeLE)) {
+            std::cerr << "TestReplayObservation: StartGame failed" << std::endl;
+            return false;
+        }
+        while (coordinator.Update()) {
+            if (bot.Observation()->GetGameLoop() > 200) {
+                break;
+            }
+        }
+        if (!bot.saved() || !std::filesystem::exists(replay_path)) {
+            std::cerr << "TestReplayObservation: SaveReplay failed at " << replay_path << std::endl;
+            return false;
+        }
+    }
+
+    std::string errors;
+    Coordinator replay_coordinator;
+    if (!replay_coordinator.LoadSettings(argc, argv)) {
+        std::cerr << "TestReplayObservation: replay LoadSettings failed" << std::endl;
+        return false;
+    }
+    if (!replay_coordinator.SetReplayPath(replay_dir.string())) {
+        std::cerr << "TestReplayObservation: SetReplayPath failed" << std::endl;
+        return false;
+    }
+
+    ReplayInfoObserver observer(&errors);
+    replay_coordinator.AddReplayObserver(&observer);
+    while (replay_coordinator.Update()) {
+    }
+
+    bool success = observer.info_ok() && observer.stepped();
+    if (!observer.info_ok()) {
+        std::cerr << "TestReplayObservation: ReplayInfo incomplete: " << errors << std::endl;
+    }
+    if (!observer.stepped()) {
+        std::cerr << "TestReplayObservation: ReplayObserver never stepped" << std::endl;
+        success = false;
+    }
+    // Camera and chat assertions land in later topic PRs. This test only
+    // requires a complete ReplayInfo including both player names.
+    (void)observer.saw_chat_text();
+    (void)observer.chat_cleared();
+    return success;
+}
+
+}  // namespace sc2

--- a/tests/test_replay_observation.cc
+++ b/tests/test_replay_observation.cc
@@ -102,10 +102,8 @@ public:
             Debug()->DebugMoveCamera(kCameraTarget);
             Debug()->SendDebug();
         }
-        if (loop >= 16 && !saved_) {
+        if (loop >= 64 && !saved_) {
             saved_ = Control()->SaveReplay(replay_path_);
-            Debug()->DebugEndGame(true);
-            Debug()->SendDebug();
         }
     }
 
@@ -184,10 +182,10 @@ private:
 }  // namespace
 
 bool TestReplayObservation(int argc, char** argv) {
-    const std::filesystem::path replay_dir = std::filesystem::temp_directory_path() / "cpp-sc2-replay-obs";
+    const std::filesystem::path replay_dir = std::filesystem::path(GetLibraryMapsDirectory()) / "ReplayFixtures";
     std::error_code ec;
     std::filesystem::create_directories(replay_dir, ec);
-    const std::string replay_path = (replay_dir / "fixture.SC2Replay").string();
+    const std::string replay_path = (replay_dir / "cpp_sc2_fixture.SC2Replay").string();
     std::filesystem::remove(replay_path, ec);
 
     {
@@ -196,6 +194,7 @@ bool TestReplayObservation(int argc, char** argv) {
             std::cerr << "TestReplayObservation: LoadSettings failed" << std::endl;
             return false;
         }
+        coordinator.SetTimeoutMS(120000);
 
         ReplayCaptureBot bot(replay_path);
         coordinator.SetParticipants({
@@ -208,12 +207,18 @@ bool TestReplayObservation(int argc, char** argv) {
             return false;
         }
         while (coordinator.Update()) {
-            if (bot.Observation()->GetGameLoop() > 200) {
+            SleepFor(20);
+            if (bot.saved()) {
+                break;
+            }
+            if (bot.Observation()->GetGameLoop() > 256) {
                 break;
             }
         }
-        if (!bot.saved() || !std::filesystem::exists(replay_path)) {
-            std::cerr << "TestReplayObservation: SaveReplay failed at " << replay_path << std::endl;
+        const auto size = std::filesystem::exists(replay_path) ? std::filesystem::file_size(replay_path) : 0;
+        if (!bot.saved() || size < 1000) {
+            std::cerr << "TestReplayObservation: SaveReplay failed at " << replay_path << " size=" << size
+                      << " loop=" << bot.Observation()->GetGameLoop() << std::endl;
             return false;
         }
     }

--- a/tests/test_replay_observation.h
+++ b/tests/test_replay_observation.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace sc2 {
+
+bool TestReplayObservation(int argc, char** argv);
+
+}  // namespace sc2

--- a/tests/test_replay_observation_main.cc
+++ b/tests/test_replay_observation_main.cc
@@ -1,5 +1,0 @@
-#include "test_replay_observation.h"
-
-int main(int argc, char* argv[]) {
-    return sc2::TestReplayObservation(argc, argv) ? 0 : 1;
-}

--- a/tests/test_replay_observation_main.cc
+++ b/tests/test_replay_observation_main.cc
@@ -1,0 +1,5 @@
+#include "test_replay_observation.h"
+
+int main(int argc, char* argv[]) {
+    return sc2::TestReplayObservation(argc, argv) ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #102.

## Why
ConvertRawActions skipped raw camera pans, so replay and DebugMoveCamera
moves never showed up in observations. Stuffing them into ActionRaw left
ability/unit fields unused.

## What
- RawCameraMove (Point3D world-space center) on GetRawCameraMoves().
- OnCameraMove for each pan this step (IssueEvents, before OnStep).
- ActionRaw stays unit commands only.
- echo_actions prints camera overlay when no unit command is echoed.
- test_replay_observation pans to playable center, asserts live and
  recorded raw pans, and checks spectator ObserverAction::CameraMove does
  not appear as a raw move.

Not in this PR: spectator camera pose. The protocol has no observer camera
in Observation, and ResponseObserverAction is empty.

## Tested
Live SC2 (Windows, Base97563), Bel'Shir Vestige LE. TestReplayObservation
passed: DebugMoveCamera seen live, recorded pan in replay, spectator pan
does not show up in GetRawCameraMoves.