### PR TITLE
feat: add bot-owned Unit::user pointer (#80)

### DIFF
--- a/src/sc2api/sc2_unit.cc
+++ b/src/sc2api/sc2_unit.cc
@@ -33,6 +33,7 @@ Unit* UnitPool::CreateUnit(Tag tag) {
     std::vector<Unit>& pool = unit_pool_[available_index_.first];
     Unit* unit = &pool[available_index_.second];
     unit->last_seen_game_loop = 0;  // initialization required for OnUnitEnterVision
+    unit->user = nullptr;
     tag_to_unit_[tag] = unit;
     tag_to_existing_unit_[tag] = unit;
     AddNewUnit(unit);

--- a/src/sc2api/sc2_unit.h
+++ b/src/sc2api/sc2_unit.h
@@ -197,6 +197,19 @@ public:
     //! Whether the unit is building or not.
     bool is_building;
 
+    //! Optional bot-owned pointer. The library never dereferences or deletes this.
+    //! Survives across observations for the same tag. New units start as nullptr.
+    //! Free any heap allocation in OnUnitDestroyed (or when you clear it).
+    void* user = nullptr;
+
+    void SetUser(void* user_data) {
+        user = user_data;
+    }
+
+    [[nodiscard]] void* User() const {
+        return user;
+    }
+
     //! Whether the unit construction/training completed.
     [[nodiscard]] bool IsBuildFinished() const;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,3 +28,7 @@ if (BUILD_SC2_RENDERER)
 endif ()
 
 target_link_libraries(all_tests sc2api sc2lib sc2utils)
+
+add_executable(test_unit_pool test_unit_pool.cc)
+set_target_properties(test_unit_pool PROPERTIES FOLDER tests)
+target_link_libraries(test_unit_pool sc2api)

--- a/tests/test_unit_pool.cc
+++ b/tests/test_unit_pool.cc
@@ -1,0 +1,43 @@
+#include <iostream>
+
+#include "sc2api/sc2_unit.h"
+
+int main() {
+    sc2::UnitPool pool;
+
+    sc2::Unit* first = pool.CreateUnit(1);
+    if (!first) {
+        std::cerr << "CreateUnit returned null\n";
+        return 1;
+    }
+    if (first->User() != nullptr) {
+        std::cerr << "new unit user pointer must be null\n";
+        return 1;
+    }
+
+    int marker = 42;
+    first->SetUser(&marker);
+
+    sc2::Unit* same = pool.CreateUnit(1);
+    if (same != first) {
+        std::cerr << "same tag must reuse the Unit\n";
+        return 1;
+    }
+    if (same->User() != &marker) {
+        std::cerr << "user pointer must survive CreateUnit for a living tag\n";
+        return 1;
+    }
+
+    sc2::Unit* second = pool.CreateUnit(2);
+    if (!second || second == first) {
+        std::cerr << "new tag must allocate a different Unit\n";
+        return 1;
+    }
+    if (second->User() != nullptr) {
+        std::cerr << "unrelated unit must not inherit user pointer\n";
+        return 1;
+    }
+
+    std::cout << "test_unit_pool succeeded.\n";
+    return 0;
+}


### PR DESCRIPTION
Fixes #80.

## Why
Bots need per-unit marks (gas workers, squad id, etc.). `Unit` had no
bot-owned field, so callers kept a side map keyed by tag and had to
keep it in sync with create/destroy.

## What
- Add `void* user` on `Unit`. The library never dereferences or deletes it.
- Same tag reuses the same `Unit` object, so the pointer survives
  observations. New units start as `nullptr` (`CreateUnit` clears it).
- Accessors: `SetUser` / `User()`. The field is public like the rest of
  `Unit`.
- Caller owns the pointed-to object. Free heap allocations in
  `OnUnitDestroyed` (or when you clear the pointer).

## Tested
`test_unit_pool` (no SC2):
- New unit: `User()` is null.
- Same tag: `CreateUnit` returns the same `Unit` and keeps the pointer.
- New tag: different `Unit`, pointer stays null (no leak from a sibling).